### PR TITLE
Revert auth0 dependencies scope to api (compile)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,9 +60,9 @@ dependencies {
     implementation 'javax.servlet:javax.servlet-api:3.1.0'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.60'
     implementation 'org.apache.commons:commons-lang3:3.8.1'
-    implementation 'com.auth0:auth0:1.10.0'
-    implementation 'com.auth0:java-jwt:3.5.0'
-    implementation 'com.auth0:jwks-rsa:0.7.0'
+    api 'com.auth0:auth0:1.10.0'
+    api 'com.auth0:java-jwt:3.5.0'
+    api 'com.auth0:jwks-rsa:0.7.0'
 
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'
     testImplementation 'org.hamcrest:hamcrest-core:1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation 'org.bouncycastle:bcprov-jdk15on:1.60'
     implementation 'org.apache.commons:commons-lang3:3.8.1'
     api 'com.auth0:auth0:1.10.0'
-    api 'com.auth0:java-jwt:3.5.0'
+    api 'com.auth0:java-jwt:3.7.0'
     api 'com.auth0:jwks-rsa:0.7.0'
 
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'


### PR DESCRIPTION
### Changes

Change auth0 dependencies scope to `api` rather than just `implementation`.

### References
Will fix https://github.com/auth0/auth0-java-mvc-common/issues/19

### Testing

When this library is used on a new project, there should be no need to explicitly add as dependencies the JWT, JWKS RSA or Auth0 Java libraries. This was the behavior observed until version `1.0.2` but changed when the OSS plugin was updated. This PR will revert that behavior.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
