### PR TITLE
Allow telemetry to dynamically obtain the package version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-        classpath 'gradle.plugin.com.auth0.gradle:oss-library:0.8.0'
+        classpath 'gradle.plugin.com.auth0.gradle:oss-library:0.9.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation 'javax.servlet:javax.servlet-api:3.1.0'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.60'
     implementation 'org.apache.commons:commons-lang3:3.8.1'
-    api 'com.auth0:auth0:1.12.0'
+    api 'com.auth0:auth0:1.13.2'
     api 'com.auth0:java-jwt:3.8.0'
     api 'com.auth0:jwks-rsa:0.8.0'
 

--- a/src/main/java/com/auth0/AuthenticationController.java
+++ b/src/main/java/com/auth0/AuthenticationController.java
@@ -127,6 +127,13 @@ public class AuthenticationController {
     }
 
     /**
+     * Disable sending the Telemetry header on every request to the Auth0 API
+     */
+    public void doNotSendTelemetry() {
+        requestProcessor.getClient().doNotSendTelemetry();
+    }
+
+    /**
      * Processes a request validating the received parameters and performs a Code Exchange or a Token's Signature Verification,
      * depending on the chosen Response Type, to finally obtain a set of {@link Tokens}.
      *

--- a/src/main/java/com/auth0/RequestProcessorFactory.java
+++ b/src/main/java/com/auth0/RequestProcessorFactory.java
@@ -2,6 +2,8 @@ package com.auth0;
 
 import com.auth0.client.auth.AuthAPI;
 import com.auth0.jwk.JwkProvider;
+import com.auth0.net.Telemetry;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.Validate;
 
 import java.io.UnsupportedEncodingException;
@@ -15,6 +17,7 @@ class RequestProcessorFactory {
         Validate.notNull(responseType);
 
         AuthAPI client = new AuthAPI(domain, clientId, clientSecret);
+        setupTelemetry(client);
         return new RequestProcessor(client, responseType, null);
     }
 
@@ -25,6 +28,7 @@ class RequestProcessorFactory {
         Validate.notNull(responseType);
 
         AuthAPI client = new AuthAPI(domain, clientId, clientSecret);
+        setupTelemetry(client);
         TokenVerifier verifier = new TokenVerifier(clientSecret, clientId, domain);
         return new RequestProcessor(client, responseType, verifier);
     }
@@ -37,8 +41,21 @@ class RequestProcessorFactory {
         Validate.notNull(provider);
 
         AuthAPI client = new AuthAPI(domain, clientId, clientSecret);
+        setupTelemetry(client);
         TokenVerifier verifier = new TokenVerifier(provider, clientId, domain);
         return new RequestProcessor(client, responseType, verifier);
     }
 
+    @VisibleForTesting
+    void setupTelemetry(AuthAPI client) {
+        Telemetry telemetry = new Telemetry("auth0-java-mvc-common", obtainPackageVersion());
+        client.setTelemetry(telemetry);
+    }
+
+    @VisibleForTesting
+    String obtainPackageVersion() {
+        //Value if taken from jar's manifest file.
+        //Call will return null on dev environment (outside of a jar)
+        return RequestProcessorFactory.class.getPackage().getImplementationVersion();
+    }
 }

--- a/src/test/java/com/auth0/AuthenticationControllerTest.java
+++ b/src/test/java/com/auth0/AuthenticationControllerTest.java
@@ -233,4 +233,15 @@ public class AuthenticationControllerTest {
         verify(client).setLoggingEnabled(false);
     }
 
+    @Test
+    public void shouldDisableTelemetry() throws Exception {
+        RequestProcessorFactory requestProcessorFactory = mock(RequestProcessorFactory.class);
+        when(requestProcessorFactory.forCodeGrant("domain", "clientId", "clientSecret", "code")).thenReturn(requestProcessor);
+        AuthenticationController controller = AuthenticationController.newBuilder("domain", "clientId", "clientSecret")
+                .build(requestProcessorFactory);
+
+        controller.doNotSendTelemetry();
+        verify(client).doNotSendTelemetry();
+    }
+
 }

--- a/src/test/java/com/auth0/RequestProcessorFactoryTest.java
+++ b/src/test/java/com/auth0/RequestProcessorFactoryTest.java
@@ -1,43 +1,56 @@
 package com.auth0;
 
+import com.auth0.client.auth.AuthAPI;
 import com.auth0.jwk.JwkProvider;
+import com.auth0.net.Telemetry;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.MockitoAnnotations;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 public class RequestProcessorFactoryTest {
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
-    private RequestProcessorFactory factory;
+    private RequestProcessorFactory factorySpy;
+    private ArgumentCaptor<AuthAPI> clientCaptor;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
-        factory = new RequestProcessorFactory();
+        RequestProcessorFactory factory = new RequestProcessorFactory();
+        factorySpy = Mockito.spy(factory);
+        clientCaptor = ArgumentCaptor.forClass(AuthAPI.class);
     }
 
     @Test
     public void shouldCreateForCodeGrant() throws Exception {
-        RequestProcessor processor = factory.forCodeGrant("domain", "clientId", "clientSecret", "responseType");
+        RequestProcessor processor = factorySpy.forCodeGrant("domain", "clientId", "clientSecret", "responseType");
+        verify(factorySpy).setupTelemetry(clientCaptor.capture());
+        AuthAPI capturedClient = clientCaptor.getValue();
+        assertThat(capturedClient, is(notNullValue()));
+
         assertThat(processor, is(notNullValue()));
-        assertThat(processor.client, is(notNullValue()));
+        assertThat(processor.client, is(capturedClient));
         assertThat(processor.responseType, is("responseType"));
         assertThat(processor.verifier, is(nullValue()));
     }
 
     @Test
     public void shouldCreateForImplicitGrantHS() throws Exception {
-        RequestProcessor processor = factory.forImplicitGrant("domain", "clientId", "clientSecret", "responseType");
+        RequestProcessor processor = factorySpy.forImplicitGrant("domain", "clientId", "clientSecret", "responseType");
+        verify(factorySpy).setupTelemetry(clientCaptor.capture());
+        AuthAPI capturedClient = clientCaptor.getValue();
+        assertThat(capturedClient, is(notNullValue()));
+
         assertThat(processor, is(notNullValue()));
-        assertThat(processor.client, is(notNullValue()));
+        assertThat(processor.client, is(capturedClient));
         assertThat(processor.responseType, is("responseType"));
         assertThat(processor.verifier, is(notNullValue()));
     }
@@ -45,11 +58,29 @@ public class RequestProcessorFactoryTest {
     @Test
     public void shouldCreateForImplicitGrantRS() throws Exception {
         JwkProvider jwkProvider = mock(JwkProvider.class);
-        RequestProcessor processor = factory.forImplicitGrant("domain", "clientId", "clientSecret", "responseType", jwkProvider);
+        RequestProcessor processor = factorySpy.forImplicitGrant("domain", "clientId", "clientSecret", "responseType", jwkProvider);
+        verify(factorySpy).setupTelemetry(clientCaptor.capture());
+        AuthAPI capturedClient = clientCaptor.getValue();
+        assertThat(capturedClient, is(notNullValue()));
+
         assertThat(processor, is(notNullValue()));
-        assertThat(processor.client, is(notNullValue()));
+        assertThat(processor.client, is(capturedClient));
         assertThat(processor.responseType, is("responseType"));
         assertThat(processor.verifier, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldSetupAClientWithTelemetry() throws Exception {
+        ArgumentCaptor<Telemetry> telemetryCaptor = ArgumentCaptor.forClass(Telemetry.class);
+        AuthAPI client = mock(AuthAPI.class);
+        when(factorySpy.obtainPackageVersion()).thenReturn("1.2.3");
+        factorySpy.setupTelemetry(client);
+
+        verify(client).setTelemetry(telemetryCaptor.capture());
+        Telemetry capturedTelemetry = telemetryCaptor.getValue();
+        assertThat(capturedTelemetry, is(notNullValue()));
+        assertThat(capturedTelemetry.getName(), is("auth0-java-mvc-common"));
+        assertThat(capturedTelemetry.getVersion(), is("1.2.3"));
     }
 
 }


### PR DESCRIPTION
### Changes
Version is now obtained from the jar's manifest. This PR also allows to disable the telemetry header on demand.

### Testing

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of Java or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
