### PR TITLE
Rollback to fixed dependencies versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,9 +60,9 @@ dependencies {
     implementation 'javax.servlet:javax.servlet-api:3.1.0'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.61'
     implementation 'org.apache.commons:commons-lang3:3.9'
-    api 'com.auth0:auth0:1.13.+'
-    api 'com.auth0:java-jwt:3.8.+'
-    api 'com.auth0:jwks-rsa:0.8.+'
+    api 'com.auth0:auth0:1.13.3'
+    api 'com.auth0:java-jwt:3.8.1'
+    api 'com.auth0:jwks-rsa:0.8.2'
 
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'
     testImplementation 'org.hamcrest:hamcrest-core:1.3'


### PR DESCRIPTION
### Changes

This was blocking our sync with maven central as the pom being generated by our plugin is not accurate when using dynamic versions.