### PR TITLE
Update to latest auth0-java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation 'javax.servlet:javax.servlet-api:3.1.0'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.61'
     implementation 'org.apache.commons:commons-lang3:3.9'
-    api 'com.auth0:auth0:1.13.3'
+    api 'com.auth0:auth0:1.14.1'
     api 'com.auth0:java-jwt:3.8.1'
     api 'com.auth0:jwks-rsa:0.8.2'
 


### PR DESCRIPTION
**Changes**
Bump`auth0-java` dependency to latest, to address CVE-2019-12384 and CVE-2019-12814

**References**
https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-450917
https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-450207
