### PR TITLE
Find the right JDK version for Telemetry

### DIFF
--- a/src/main/java/com/auth0/RequestProcessorFactory.java
+++ b/src/main/java/com/auth0/RequestProcessorFactory.java
@@ -10,6 +10,8 @@ import java.io.UnsupportedEncodingException;
 
 class RequestProcessorFactory {
 
+    private static final String JAVA_SPECIFICATION_VERSION = "java.specification.version";
+
     RequestProcessor forCodeGrant(String domain, String clientId, String clientSecret, String responseType) {
         Validate.notNull(domain);
         Validate.notNull(clientId);
@@ -56,6 +58,12 @@ class RequestProcessorFactory {
     String obtainPackageVersion() {
         //Value if taken from jar's manifest file.
         //Call will return null on dev environment (outside of a jar)
-        return RequestProcessorFactory.class.getPackage().getImplementationVersion();
+        String version;
+        try {
+            version = System.getProperty(JAVA_SPECIFICATION_VERSION);
+        } catch (Exception ignored) {
+            version = RequestProcessorFactory.class.getPackage().getImplementationVersion();
+        }
+        return version;
     }
 }


### PR DESCRIPTION
### Changes

JDK 9 was now uploading the right telemetry version, and so a null was being registered.

### References


![image](https://user-images.githubusercontent.com/3900123/62565786-eda51880-b85d-11e9-80cd-27cf807ef382.png)


### Testing

No additional tests as these are static methods and depend on the JVM they are being run on.


### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
