### PR TITLE
Update to JDK 8 and Servlet API 4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ jacocoTestReport {
 }
 
 compileJava {
-    sourceCompatibility '1.7'
-    targetCompatibility '1.7'
+    sourceCompatibility '1.8'
+    targetCompatibility '1.8'
 }
 
 test {
@@ -57,8 +57,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'javax.servlet:javax.servlet-api:3.1.0'
-    implementation 'org.bouncycastle:bcprov-jdk15on:1.61'
+    implementation 'javax.servlet:javax.servlet-api:4.0.1'
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.64'
     implementation 'org.apache.commons:commons-lang3:3.9'
     api 'com.auth0:auth0:1.14.3'
     api 'com.auth0:java-jwt:3.8.3'


### PR DESCRIPTION
### Changes

Targeting JDK 8 and Servlet API 4 in 2.0.0.
 
* Update source and target compatibility to JDK 8
* Update Servlet API dependency to v4
* Update to latest Bouncy Castle dependency

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
