### PR TITLE
Add SameSite Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ String authorizeUrl = authController.buildAuthorizeUrl(request, response, "https
 try {
     Tokens tokens = authController.handle(request, response);
     //Use or store the tokens
-    request.getSession().setAttrigbute("id_token", tokens.getIdToken());
+    request.getSession().setAttribute("access_token", tokens.getAccessToken());
 } catch (IdentityVerificationException e) {
     String code = e.getCode();
     // Something happened when trying to process the request.

--- a/README.md
+++ b/README.md
@@ -49,17 +49,17 @@ AuthenticationController controller = AuthenticationController.newBuilder("domai
 
 ```java
 //let the library generate the state/nonce parameters
-String authorizeUrl = authController.buildAuthorizeUrl(request, "https://redirect.uri/here")
+String authorizeUrl = authController.buildAuthorizeUrl(request, response, "https://redirect.uri/here")
     .build();
 
 // or use custom state/nonce parameters
-String authorizeUrl = authController.buildAuthorizeUrl(request, "https://redirect.uri/here")
+String authorizeUrl = authController.buildAuthorizeUrl(request, response, "https://redirect.uri/here")
     .withState("state")
     .withNonce("nonce")
     .build();
 
 // you can also specify custom parameters
-String authorizeUrl = authController.buildAuthorizeUrl(request, "https://redirect.uri/here")
+String authorizeUrl = authController.buildAuthorizeUrl(request, response, "https://redirect.uri/here")
     .withAudience("https://myapi.me.auth0.com")
     .withScope("openid create:photos read:photos")
     .withParameter("name", "value")
@@ -73,9 +73,9 @@ String authorizeUrl = authController.buildAuthorizeUrl(request, "https://redirec
 
 ```java
 try {
-    Tokens tokens = authController.handle(request);
+    Tokens tokens = authController.handle(request, response);
     //Use or store the tokens
-    SessionUtils.set(request, "access_token", tokens.getAccessToken());
+    request.getSession().setAttrigbute("id_token", tokens.getIdToken());
 } catch (IdentityVerificationException e) {
     String code = e.getCode();
     // Something happened when trying to process the request.

--- a/src/main/java/com/auth0/AuthCookie.java
+++ b/src/main/java/com/auth0/AuthCookie.java
@@ -2,6 +2,10 @@ package com.auth0;
 
 import org.apache.commons.lang3.Validate;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 /**
  * Represents a cookie to be used for transfer of authentiction-based data such as state and nonce.
  *
@@ -21,8 +25,6 @@ class AuthCookie {
 
     /**
      * Create a new instance.
-     *
-     * Note that keys and values are stored as-is. Clients should encode and decode values as needed.
      *
      * @param key The cookie key
      * @param value The cookie value
@@ -55,13 +57,15 @@ class AuthCookie {
 
     /**
      * Builds and returns a string representing this cookie instance, to be used as the value of a "Set-Cookie" header.
+     * The cookie key and value will be URL-encoded using the UTF-8 character set.
      *
+     * @throws AssertionError if the UTF-8 character set is not supported on the running JVM.
      * @return the value of this cookie as a string to be used as the value of a "Set-Cookie" header.
      */
     String buildHeaderString() {
-        String baseCookieString = String.format("%s=%s; HttpOnly; Max-Age=%d", key, value, MAX_AGE_SECONDS);
+        String baseCookieString = String.format("%s=%s; HttpOnly; Max-Age=%d", encode(key), encode(value), MAX_AGE_SECONDS);
         if (sameSite != null) {
-            baseCookieString = baseCookieString.concat(String.format("; SameSite=%s", sameSite.getValue()));
+            baseCookieString = baseCookieString.concat(String.format("; SameSite=%s", encode(sameSite.getValue())));
         }
         if (secure) {
             baseCookieString = baseCookieString.concat("; Secure");
@@ -69,4 +73,11 @@ class AuthCookie {
         return baseCookieString;
     }
 
+    private static String encode(String valueToEncode) {
+        try {
+            return URLEncoder.encode(valueToEncode, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new AssertionError("UTF-8 character set not supported", e.getCause());
+        }
+    }
 }

--- a/src/main/java/com/auth0/AuthCookie.java
+++ b/src/main/java/com/auth0/AuthCookie.java
@@ -1,0 +1,72 @@
+package com.auth0;
+
+import org.apache.commons.lang3.Validate;
+
+/**
+ * Represents a cookie to be used for transfer of authentiction-based data such as state and nonce.
+ *
+ * This is an internal replacement for the Java Servlet Cookie implementation, so that it can set the SameSite
+ * attribute (not yet supported in Java Servlet API). It is intended to be used via the Set-Cookie header.
+ *
+ * By default, cookies will have the HttpOnly attribute set, and a Max-Age of 600 seconds (10 minutes).
+ */
+class AuthCookie {
+
+    private final static int MAX_AGE_SECONDS = 600; // 10 minutes
+
+    private final String key;
+    private final String value;
+    private boolean secure;
+    private SameSite sameSite;
+
+    /**
+     * Create a new instance.
+     *
+     * Note that keys and values are stored as-is. Clients should encode and decode values as needed.
+     *
+     * @param key The cookie key
+     * @param value The cookie value
+     */
+    AuthCookie(String key, String value) {
+        Validate.notNull(key, "Key must not be null");
+        Validate.notNull(value, "Value must not be null");
+
+        this.key = key;
+        this.value = value;
+    }
+
+    /**
+     * Sets whether the Secure attribute should be set on the cookie. False by default.
+     *
+     * @param secure whether the Cookie should have the Secure attribute or not.
+     */
+    void setSecure(boolean secure) {
+        this.secure = secure;
+    }
+
+    /**
+     * Sets the value of the SameSite attribute. Unless set, no SameSite attribute will be set on the cookie.
+     *
+     * @param sameSite The value of the SameSite attribute.
+     */
+    void setSameSite(SameSite sameSite) {
+        this.sameSite = sameSite;
+    }
+
+    /**
+     * Builds and returns a string representing this cookie instance, to be used as the value of a "Set-Cookie" header.
+     *
+     * @return the value of this cookie as a string to be used as the value of a "Set-Cookie" header.
+     */
+    String buildHeaderString() {
+        String baseCookieString = String.format("%s=%s; HttpOnly; Max-Age=%d", key, value, MAX_AGE_SECONDS);
+        if (sameSite != null) {
+            baseCookieString = baseCookieString.concat(String.format("; SameSite=%s", sameSite.getValue()));
+        }
+        if (secure) {
+            baseCookieString = baseCookieString.concat("; Secure");
+        }
+        return baseCookieString;
+    }
+
+}

--- a/src/main/java/com/auth0/AuthenticationController.java
+++ b/src/main/java/com/auth0/AuthenticationController.java
@@ -57,7 +57,7 @@ public class AuthenticationController {
         private JwkProvider jwkProvider;
         private Integer clockSkew;
         private Integer authenticationMaxAge;
-        private boolean legacySameSiteCookie;
+        private boolean useLegacySameSiteCookie;
 
         Builder(String domain, String clientId, String clientSecret) {
             Validate.notNull(domain);
@@ -68,7 +68,7 @@ public class AuthenticationController {
             this.clientId = clientId;
             this.clientSecret = clientSecret;
             this.responseType = RESPONSE_TYPE_CODE;
-            this.legacySameSiteCookie = true;
+            this.useLegacySameSiteCookie = true;
         }
 
         /**
@@ -126,11 +126,11 @@ public class AuthenticationController {
          * Sets whether fallback cookies will be set for clients that do not support SameSite=None cookie attribute.
          * The SameSite Cookie attribute will only be set to "None" if the reponseType includes "id_token".
          * By default this is true.
-         * @param legacySameSiteCookie whether fallback auth-based cookies should be set.
+         * @param useLegacySameSiteCookie whether fallback auth-based cookies should be set.
          * @return this same builder instance.
          */
-        public Builder withLegacySameSiteCookie(boolean legacySameSiteCookie) {
-            this.legacySameSiteCookie = legacySameSiteCookie;
+        public Builder withLegacySameSiteCookie(boolean useLegacySameSiteCookie) {
+            this.useLegacySameSiteCookie = useLegacySameSiteCookie;
             return this;
         }
 
@@ -161,7 +161,7 @@ public class AuthenticationController {
             IdTokenVerifier.Options verifyOptions = createIdTokenVerificationOptions(issuer, clientId, signatureVerifier);
             verifyOptions.setClockSkew(clockSkew);
             verifyOptions.setMaxAge(authenticationMaxAge);
-            RequestProcessor processor = new RequestProcessor(apiClient, responseType, verifyOptions, legacySameSiteCookie);
+            RequestProcessor processor = new RequestProcessor(apiClient, responseType, verifyOptions, useLegacySameSiteCookie);
             return new AuthenticationController(processor);
         }
 

--- a/src/main/java/com/auth0/AuthenticationController.java
+++ b/src/main/java/com/auth0/AuthenticationController.java
@@ -245,16 +245,12 @@ public class AuthenticationController {
      * when building the {@link AuthorizeUrl} that the user will be redirected to to login. Failure to do so may result
      * in a broken login experience for the user.</p>
      *
-     * @deprecated This method uses the HttpSession for auth-based data, and is incompatible with clients that are using the
-     * "id_token" or "token" responseType with browsers that enforce SameSite cookie restrictions. This method will be removed
-     * in version 2.0.0.
-     *
      * @param request the received request to process.
      * @return the Tokens obtained after the user authentication.
      * @throws InvalidRequestException       if the error is result of making an invalid authentication request.
      * @throws IdentityVerificationException if an error occurred while verifying the request tokens.
      */
-    @Deprecated
+    // TODO - deprecate in minor version, remove in next major
     public Tokens handle(HttpServletRequest request) throws IdentityVerificationException {
         Validate.notNull(request);
 
@@ -268,16 +264,11 @@ public class AuthenticationController {
      * {@link AuthenticationController#handle(HttpServletRequest)} method. Failure to do so may result in a broken login
      * experience for users.
      *
-     * @deprecated This method stores data in the HttpSession, and is incompatible with clients that are using the "id_token"
-     * or "token" responseType with browsers that enforce SameSite cookie restrictions. This method will be removed in
-     * version 2.0.0
-     * <p>Use {@link AuthenticationController#buildAuthorizeUrl(HttpServletRequest, HttpServletResponse, String)} instead</p>
-     *
      * @param request     the caller request. Used to keep the session context.
      * @param redirectUri the url to call back with the authentication result.
      * @return the authorize url builder to continue any further parameter customization.
      */
-    @Deprecated
+    // TODO - deprecate in minor version, remove in next major
     public AuthorizeUrl buildAuthorizeUrl(HttpServletRequest request, String redirectUri) {
         return buildAuthorizeUrl(request, null, redirectUri);
     }

--- a/src/main/java/com/auth0/AuthenticationController.java
+++ b/src/main/java/com/auth0/AuthenticationController.java
@@ -217,8 +217,11 @@ public class AuthenticationController {
     }
 
     /**
-     * Processes a request validating the received parameters and performs a Code Exchange or a Token's Signature Verification,
-     * depending on the chosen Response Type, to obtain a set of {@link Tokens}.
+     * Process a request to obtain a set of {@link Tokens} that represent successful authentication or authorization.
+     *
+     * This method should be called when processing the callback request to your application. It will validate
+     * authentication-related request parameters, handle performing a Code Exchange request if using
+     * the "code" response type, and verify the integrity of the ID token (if present).
      *
      * <p><strong>Important:</strong> When using this API, you <strong>must</strong> also use {@link AuthenticationController#buildAuthorizeUrl(HttpServletRequest, HttpServletResponse, String)}
      * when building the {@link AuthorizeUrl} that the user will be redirected to to login. Failure to do so may result
@@ -238,8 +241,11 @@ public class AuthenticationController {
     }
 
     /**
-     * Processes a request validating the received parameters and performs a Code Exchange or a Token's Signature Verification,
-     * depending on the chosen Response Type, to obtain a set of {@link Tokens}.
+     * Process a request to obtain a set of {@link Tokens} that represent successful authentication or authorization.
+     *
+     * This method should be called when processing the callback request to your application. It will validate
+     * authentication-related request parameters, handle performing a Code Exchange request if using
+     * the "code" response type, and verify the integrity of the ID token (if present).
      *
      * <p><strong>Important:</strong> When using this API, you <strong>must</strong> also use the {@link AuthenticationController#buildAuthorizeUrl(HttpServletRequest, String)}
      * when building the {@link AuthorizeUrl} that the user will be redirected to to login. Failure to do so may result

--- a/src/main/java/com/auth0/AuthenticationController.java
+++ b/src/main/java/com/auth0/AuthenticationController.java
@@ -220,7 +220,7 @@ public class AuthenticationController {
      * Processes a request validating the received parameters and performs a Code Exchange or a Token's Signature Verification,
      * depending on the chosen Response Type, to obtain a set of {@link Tokens}.
      *
-     * <p><strong>Important:</strong> When using this API, you <strong>must</strong> also use the {@link AuthenticationController#buildAuthorizeUrl(HttpServletRequest, HttpServletResponse, String)}
+     * <p><strong>Important:</strong> When using this API, you <strong>must</strong> also use {@link AuthenticationController#buildAuthorizeUrl(HttpServletRequest, HttpServletResponse, String)}
      * when building the {@link AuthorizeUrl} that the user will be redirected to to login. Failure to do so may result
      * in a broken login experience for the user.</p>
      *

--- a/src/main/java/com/auth0/AuthenticationController.java
+++ b/src/main/java/com/auth0/AuthenticationController.java
@@ -231,8 +231,8 @@ public class AuthenticationController {
      * @throws IdentityVerificationException if an error occurred while verifying the request tokens.
      */
     public Tokens handle(HttpServletRequest request, HttpServletResponse response) throws IdentityVerificationException {
-        Validate.notNull(request);
-        Validate.notNull(response);
+        Validate.notNull(request, "request must not be null");
+        Validate.notNull(response, "response must not be null");
 
         return requestProcessor.process(request, response);
     }
@@ -252,7 +252,7 @@ public class AuthenticationController {
      */
     // TODO - deprecate in minor version, remove in next major
     public Tokens handle(HttpServletRequest request) throws IdentityVerificationException {
-        Validate.notNull(request);
+        Validate.notNull(request, "request must not be null");
 
         return requestProcessor.process(request, null);
     }
@@ -286,8 +286,8 @@ public class AuthenticationController {
      * @return the authorize url builder to continue any further parameter customization.
      */
     public AuthorizeUrl buildAuthorizeUrl(HttpServletRequest request, HttpServletResponse response, String redirectUri) {
-        Validate.notNull(request);
-        Validate.notNull(redirectUri);
+        Validate.notNull(request, "request must not be null");
+        Validate.notNull(redirectUri, "redirectUri must not be null");
 
         String state = StorageUtils.secureRandomString();
         String nonce = StorageUtils.secureRandomString();

--- a/src/main/java/com/auth0/AuthenticationController.java
+++ b/src/main/java/com/auth0/AuthenticationController.java
@@ -270,7 +270,13 @@ public class AuthenticationController {
      */
     // TODO - deprecate in minor version, remove in next major
     public AuthorizeUrl buildAuthorizeUrl(HttpServletRequest request, String redirectUri) {
-        return buildAuthorizeUrl(request, null, redirectUri);
+        Validate.notNull(request, "request must not be null");
+        Validate.notNull(redirectUri, "redirectUri must not be null");
+
+        String state = StorageUtils.secureRandomString();
+        String nonce = StorageUtils.secureRandomString();
+
+        return requestProcessor.buildAuthorizeUrl(request, null, redirectUri, state, nonce);
     }
 
     /**
@@ -287,6 +293,7 @@ public class AuthenticationController {
      */
     public AuthorizeUrl buildAuthorizeUrl(HttpServletRequest request, HttpServletResponse response, String redirectUri) {
         Validate.notNull(request, "request must not be null");
+        Validate.notNull(response, "response must not be null");
         Validate.notNull(redirectUri, "redirectUri must not be null");
 
         String state = StorageUtils.secureRandomString();

--- a/src/main/java/com/auth0/AuthorizeUrl.java
+++ b/src/main/java/com/auth0/AuthorizeUrl.java
@@ -171,8 +171,7 @@ public class AuthorizeUrl {
         }
 
         if (response != null) {
-            TransientCookieStore.SameSite sameSiteValue = containsFormPost() ?
-                    TransientCookieStore.SameSite.NONE : TransientCookieStore.SameSite.LAX;
+            SameSite sameSiteValue = containsFormPost() ? SameSite.NONE : SameSite.LAX;
 
             TransientCookieStore.storeState(response, state, sameSiteValue, useLegacySameSiteCookie);
             TransientCookieStore.storeNonce(response, nonce, sameSiteValue, useLegacySameSiteCookie);

--- a/src/main/java/com/auth0/AuthorizeUrl.java
+++ b/src/main/java/com/auth0/AuthorizeUrl.java
@@ -55,16 +55,12 @@ public class AuthorizeUrl {
      * While this class can be used directly, it's recommended that you use {@link AuthenticationController#buildAuthorizeUrl(HttpServletRequest, HttpServletResponse, String)}
      * when possible.
      *
-     * @deprecated This constructor will cause the state and nonce to be stored in the Session, and is incompatible with
-     * clients that are using the "id_token" or "token" responseType with browsers that enforce SameSite cookie restrictions.
-     * <p>Use {@link AuthorizeUrl#AuthorizeUrl(AuthAPI, HttpServletRequest, HttpServletResponse, String, String)} instead.</p>
-     *
      * @param client       the Auth0 Authentication API client
      * @param request      the request where the state and nonce will be stored in the {@link javax.servlet.http.HttpSession}
      * @param redirectUrl  the url to redirect to after authentication
      * @param responseType the response type to use
      */
-    @Deprecated
+    // TODO - deprecate in minor version, remove in next major
     AuthorizeUrl(AuthAPI client, HttpServletRequest request, String redirectUrl, String responseType) {
         this(client, request, null, redirectUrl, responseType);
         this.legacySameSiteCookie = false;

--- a/src/main/java/com/auth0/AuthorizeUrl.java
+++ b/src/main/java/com/auth0/AuthorizeUrl.java
@@ -174,27 +174,15 @@ public class AuthorizeUrl {
             TransientCookieStore.SameSite sameSiteValue = containsFormPost() ?
                     TransientCookieStore.SameSite.NONE : TransientCookieStore.SameSite.LAX;
 
-            // Also store in Session just in case developer uses deprecated
-            // AuthenticationController.handle(HttpServletRequest) API
-            if (state != null) {
-                TransientCookieStore.storeState(response, state, sameSiteValue, legacySameSiteCookie);
-                RandomStorage.setSessionState(request, state);
-            }
 
-            if (nonce != null) {
-                TransientCookieStore.storeNonce(response, nonce, sameSiteValue, legacySameSiteCookie);
-                RandomStorage.setSessionNonce(request, nonce);
-            }
-        } else {
-            if (state != null) {
-                RandomStorage.setSessionState(request, state);
-            }
-
-            if (nonce != null) {
-                RandomStorage.setSessionNonce(request, nonce);
-            }
+            TransientCookieStore.storeState(response, state, sameSiteValue, legacySameSiteCookie);
+            TransientCookieStore.storeNonce(response, nonce, sameSiteValue, legacySameSiteCookie);
         }
 
+        // Also store in Session just in case developer uses deprecated
+        // AuthenticationController.handle(HttpServletRequest) API
+        RandomStorage.setSessionState(request, state);
+        RandomStorage.setSessionNonce(request, nonce);
 
         used = true;
         return builder.build();

--- a/src/main/java/com/auth0/AuthorizeUrl.java
+++ b/src/main/java/com/auth0/AuthorizeUrl.java
@@ -174,7 +174,6 @@ public class AuthorizeUrl {
             TransientCookieStore.SameSite sameSiteValue = containsFormPost() ?
                     TransientCookieStore.SameSite.NONE : TransientCookieStore.SameSite.LAX;
 
-
             TransientCookieStore.storeState(response, state, sameSiteValue, useLegacySameSiteCookie);
             TransientCookieStore.storeNonce(response, nonce, sameSiteValue, useLegacySameSiteCookie);
         }

--- a/src/main/java/com/auth0/AuthorizeUrl.java
+++ b/src/main/java/com/auth0/AuthorizeUrl.java
@@ -22,7 +22,7 @@ public class AuthorizeUrl {
     private HttpServletRequest request;
     private final AuthorizeUrlBuilder builder;
     private final String responseType;
-    private boolean legacySameSiteCookie = true;
+    private boolean useLegacySameSiteCookie = true;
     private String nonce;
     private String state;
 
@@ -65,7 +65,7 @@ public class AuthorizeUrl {
     // TODO - deprecate in minor version, remove in next major
     AuthorizeUrl(AuthAPI client, HttpServletRequest request, String redirectUrl, String responseType) {
         this(client, request, null, redirectUrl, responseType);
-        this.legacySameSiteCookie = false;
+        this.useLegacySameSiteCookie = false;
     }
 
     /**
@@ -83,11 +83,11 @@ public class AuthorizeUrl {
      * Sets whether a fallback cookie should be used for clients that do not support "SameSite=None".
      * Only applicable when this instance is created with {@link AuthorizeUrl#AuthorizeUrl(AuthAPI, HttpServletRequest, HttpServletResponse, String, String)}.
      *
-     * @param legacySameSiteCookie whether or not to set fallback auth cookies for clients that do not support "SameSite=None"
+     * @param useLegacySameSiteCookie whether or not to set fallback auth cookies for clients that do not support "SameSite=None"
      * @return the builder instance
      */
-    AuthorizeUrl withLegacySameSiteCookie(boolean legacySameSiteCookie) {
-        this.legacySameSiteCookie = legacySameSiteCookie;
+    AuthorizeUrl withLegacySameSiteCookie(boolean useLegacySameSiteCookie) {
+        this.useLegacySameSiteCookie = useLegacySameSiteCookie;
         return this;
     }
 
@@ -175,8 +175,8 @@ public class AuthorizeUrl {
                     TransientCookieStore.SameSite.NONE : TransientCookieStore.SameSite.LAX;
 
 
-            TransientCookieStore.storeState(response, state, sameSiteValue, legacySameSiteCookie);
-            TransientCookieStore.storeNonce(response, nonce, sameSiteValue, legacySameSiteCookie);
+            TransientCookieStore.storeState(response, state, sameSiteValue, useLegacySameSiteCookie);
+            TransientCookieStore.storeNonce(response, nonce, sameSiteValue, useLegacySameSiteCookie);
         }
 
         // Also store in Session just in case developer uses deprecated
@@ -191,7 +191,7 @@ public class AuthorizeUrl {
     private boolean containsFormPost() {
         String[] splitResponseTypes = responseType.trim().split("\\s+");
         List<String> responseTypes = Collections.unmodifiableList(Arrays.asList(splitResponseTypes));
-        return RequestProcessor.requiresFormPostResponseMode((responseTypes));
+        return RequestProcessor.requiresFormPostResponseMode(responseTypes);
     }
 
 }

--- a/src/main/java/com/auth0/AuthorizeUrl.java
+++ b/src/main/java/com/auth0/AuthorizeUrl.java
@@ -31,11 +31,13 @@ public class AuthorizeUrl {
     /**
      * Creates a new instance that can be used to build an Auth0 Authorization URL.
      *
-     * While this class can be used directly, it's recommended that you use {@link AuthenticationController#buildAuthorizeUrl(HttpServletRequest, HttpServletResponse, String)}
-     * when possible.
+     * Using this constructor with a non-null {@link HttpServletResponse} will store the state and nonce as
+     * cookies when the {@link AuthorizeUrl#build()} method is called, with the appropriate SameSite attribute depending
+     * on the responseType. State and nonce will also be stored in the {@link javax.servlet.http.HttpSession} as a fallback,
+     * but this behavior will be removed in a future release, and only cookies will be used.
      *
      * @param client       the Auth0 Authentication API client
-     * @parem request      the HTTP request
+     * @parem request      the HTTP request. Used to store state and nonce as a fallback if cookies not set.
      * @param response     the response where the state and nonce will be stored as cookies
      * @param redirectUrl  the url to redirect to after authentication
      * @param responseType the response type to use
@@ -52,8 +54,8 @@ public class AuthorizeUrl {
     /**
      * Creates a new instance that can be used to build an Auth0 Authorization URL.
      *
-     * While this class can be used directly, it's recommended that you use {@link AuthenticationController#buildAuthorizeUrl(HttpServletRequest, HttpServletResponse, String)}
-     * when possible.
+     * Using this constructor will store the state and nonce in the {@link javax.servlet.http.HttpSession}, and will be
+     * deprecated and removed in the future, in favor of storing the state and nonce in Cookies.
      *
      * @param client       the Auth0 Authentication API client
      * @param request      the request where the state and nonce will be stored in the {@link javax.servlet.http.HttpSession}

--- a/src/main/java/com/auth0/RandomStorage.java
+++ b/src/main/java/com/auth0/RandomStorage.java
@@ -1,28 +1,9 @@
 package com.auth0;
 
-import org.apache.commons.codec.binary.Base64;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
-import java.security.SecureRandom;
 
 class RandomStorage extends SessionUtils {
-
-    private static final String SESSION_STATE = "com.auth0.state";
-    private static final String SESSION_NONCE = "com.auth0.nonce";
-
-    /**
-     * Generates a new random string using {@link SecureRandom}.
-     * The output can be used as State or Nonce values for API requests.
-     *
-     * @return a new random string.
-     */
-    static String secureRandomString() {
-        final SecureRandom sr = new SecureRandom();
-        final byte[] randomBytes = new byte[32];
-        sr.nextBytes(randomBytes);
-        return Base64.encodeBase64URLSafeString(randomBytes);
-    }
 
     /**
      * Check's if the request {@link HttpSession} saved state is equal to the given state.
@@ -33,7 +14,7 @@ class RandomStorage extends SessionUtils {
      * @return whether the state matches the expected one or not.
      */
     static boolean checkSessionState(HttpServletRequest req, String state) {
-        String currentState = (String) remove(req, SESSION_STATE);
+        String currentState = (String) remove(req, StorageUtils.STATE_KEY);
         return (currentState == null && state == null) || currentState != null && currentState.equals(state);
     }
 
@@ -45,7 +26,7 @@ class RandomStorage extends SessionUtils {
      * @param state the state value to set.
      */
     static void setSessionState(HttpServletRequest req, String state) {
-        set(req, SESSION_STATE, state);
+        set(req, StorageUtils.STATE_KEY, state);
     }
 
     /**
@@ -56,7 +37,7 @@ class RandomStorage extends SessionUtils {
      * @param nonce the nonce value to set.
      */
     static void setSessionNonce(HttpServletRequest req, String nonce) {
-        set(req, SESSION_NONCE, nonce);
+        set(req, StorageUtils.NONCE_KEY, nonce);
     }
 
     /**
@@ -66,6 +47,6 @@ class RandomStorage extends SessionUtils {
      * @return the nonce value or null if it was not set.
      */
     static String removeSessionNonce(HttpServletRequest req) {
-        return (String) remove(req, SESSION_NONCE);
+        return (String) remove(req, StorageUtils.NONCE_KEY);
     }
 }

--- a/src/main/java/com/auth0/SameSite.java
+++ b/src/main/java/com/auth0/SameSite.java
@@ -1,0 +1,22 @@
+package com.auth0;
+
+/**
+ * Represents the values for the SameSite cookie attribute.
+ *
+ * @see <a href="https://www.owasp.org/index.php/SameSite">OWASP - SameSite</a> for additional information about the SameSite attribute..
+ */
+enum SameSite {
+    LAX("Lax"),
+    NONE("None"),
+    STRICT("Strict");
+
+    private String value;
+
+    String getValue() {
+        return this.value;
+    }
+
+    SameSite(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/auth0/StorageUtils.java
+++ b/src/main/java/com/auth0/StorageUtils.java
@@ -1,0 +1,26 @@
+package com.auth0;
+
+import org.apache.commons.codec.binary.Base64;
+
+import java.security.SecureRandom;
+
+class StorageUtils {
+
+    private StorageUtils() {}
+
+    static final String STATE_KEY = "com.auth0.state";
+    static final String NONCE_KEY = "com.auth0.nonce";
+
+    /**
+     * Generates a new random string using {@link SecureRandom}.
+     * The output can be used as State or Nonce values for API requests.
+     *
+     * @return a new random string.
+     */
+    static String secureRandomString() {
+        final SecureRandom sr = new SecureRandom();
+        final byte[] randomBytes = new byte[32];
+        sr.nextBytes(randomBytes);
+        return Base64.encodeBase64URLSafeString(randomBytes);
+    }
+}

--- a/src/main/java/com/auth0/TransientCookieStore.java
+++ b/src/main/java/com/auth0/TransientCookieStore.java
@@ -21,8 +21,9 @@ class TransientCookieStore {
 
     /**
      * Stores a state value as a cookie on the response.
+     *
      * @param response the response object to set the cookie on
-     * @param state the value for the state cookie
+     * @param state the value for the state cookie. If null, no cookie will be set.
      * @param sameSite the value for the SameSite attribute on the cookie
      * @param legacySameSiteCookie whether to set a fallback cookie or not
      */
@@ -32,8 +33,9 @@ class TransientCookieStore {
 
     /**
      * Stores a nonce value as a cookie on the response.
+     *
      * @param response the response object to set the cookie on
-     * @param nonce the value for the nonce cookie
+     * @param nonce the value for the nonce cookie. If null, no cookie will be set.
      * @param sameSite the value for the SameSite attribute on the cookie
      * @param legacySameSiteCookie whether to set a fallback cookie or not
      */
@@ -66,8 +68,11 @@ class TransientCookieStore {
     private static void store(HttpServletResponse response, String key, String value, SameSite sameSite, boolean legacySameSiteCookie) {
         Validate.notNull(response, "response must not be null");
         Validate.notNull(key, "key must not be null");
-        Validate.notNull(value, "value must not be null");
         Validate.notNull(sameSite, "sameSite must not be null");
+
+        if (value == null) {
+            return;
+        }
 
         boolean sameSiteNone = SameSite.NONE == sameSite;
 

--- a/src/main/java/com/auth0/TransientCookieStore.java
+++ b/src/main/java/com/auth0/TransientCookieStore.java
@@ -25,10 +25,10 @@ class TransientCookieStore {
      * @param response the response object to set the cookie on
      * @param state the value for the state cookie. If null, no cookie will be set.
      * @param sameSite the value for the SameSite attribute on the cookie
-     * @param legacySameSiteCookie whether to set a fallback cookie or not
+     * @param useLegacySameSiteCookie whether to set a fallback cookie or not
      */
-    static void storeState(HttpServletResponse response, String state, SameSite sameSite, boolean legacySameSiteCookie) {
-        store(response, StorageUtils.STATE_KEY, state, sameSite, legacySameSiteCookie);
+    static void storeState(HttpServletResponse response, String state, SameSite sameSite, boolean useLegacySameSiteCookie) {
+        store(response, StorageUtils.STATE_KEY, state, sameSite, useLegacySameSiteCookie);
     }
 
     /**
@@ -37,35 +37,35 @@ class TransientCookieStore {
      * @param response the response object to set the cookie on
      * @param nonce the value for the nonce cookie. If null, no cookie will be set.
      * @param sameSite the value for the SameSite attribute on the cookie
-     * @param legacySameSiteCookie whether to set a fallback cookie or not
+     * @param useLegacySameSiteCookie whether to set a fallback cookie or not
      */
-    static void storeNonce(HttpServletResponse response, String nonce, SameSite sameSite, boolean legacySameSiteCookie) {
-        store(response, StorageUtils.NONCE_KEY, nonce, sameSite, legacySameSiteCookie);
+    static void storeNonce(HttpServletResponse response, String nonce, SameSite sameSite, boolean useLegacySameSiteCookie) {
+        store(response, StorageUtils.NONCE_KEY, nonce, sameSite, useLegacySameSiteCookie);
     }
 
     /**
      * Gets the value associated with the state cookie and removes it.
      * @param request the request object
      * @param response the response object
-     * @param legacySameSiteCookie whether to use a fallback cookie or not
+     * @param useLegacySameSiteCookie whether to use a fallback cookie or not
      * @return the value of the state cookie, if it exists
      */
-    static String getState(HttpServletRequest request, HttpServletResponse response, boolean legacySameSiteCookie) {
-        return getOnce(StorageUtils.STATE_KEY, request, response, legacySameSiteCookie);
+    static String getState(HttpServletRequest request, HttpServletResponse response, boolean useLegacySameSiteCookie) {
+        return getOnce(StorageUtils.STATE_KEY, request, response, useLegacySameSiteCookie);
     }
 
     /**
      * Gets the value associated with the nonce cookie and removes it.
      * @param request the request object
      * @param response the response object
-     * @param legacySameSiteCookie whether to use a fallback cookie or not
+     * @param useLegacySameSiteCookie whether to use a fallback cookie or not
      * @return the value of the nonce cookie, if it exists
      */
-    static String getNonce(HttpServletRequest request, HttpServletResponse response, boolean legacySameSiteCookie) {
-        return getOnce(StorageUtils.NONCE_KEY, request, response, legacySameSiteCookie);
+    static String getNonce(HttpServletRequest request, HttpServletResponse response, boolean useLegacySameSiteCookie) {
+        return getOnce(StorageUtils.NONCE_KEY, request, response, useLegacySameSiteCookie);
     }
 
-    private static void store(HttpServletResponse response, String key, String value, SameSite sameSite, boolean legacySameSiteCookie) {
+    private static void store(HttpServletResponse response, String key, String value, SameSite sameSite, boolean useLegacySameSiteCookie) {
         Validate.notNull(response, "response must not be null");
         Validate.notNull(key, "key must not be null");
         Validate.notNull(sameSite, "sameSite must not be null");
@@ -85,14 +85,14 @@ class TransientCookieStore {
         response.addHeader("Set-Cookie", cookie);
 
         // set legacy fallback cookie (if configured) for clients that won't accept SameSite=None
-        if (sameSiteNone && legacySameSiteCookie) {
+        if (sameSiteNone && useLegacySameSiteCookie) {
             String legacyCookie = String.format("%s=%s; HttpOnly; Max-Age=%d", "_" + key, value, MAX_AGE_SECONDS);
             response.addHeader("Set-Cookie", legacyCookie);
         }
 
     }
 
-    private static String getOnce(String cookieName, HttpServletRequest request, HttpServletResponse response, boolean legacySameSiteCookie) {
+    private static String getOnce(String cookieName, HttpServletRequest request, HttpServletResponse response, boolean useLegacySameSiteCookie) {
         Cookie[] cookies = request.getCookies();
         if (cookies == null) {
             return null;

--- a/src/main/java/com/auth0/TransientCookieStore.java
+++ b/src/main/java/com/auth0/TransientCookieStore.java
@@ -1,0 +1,149 @@
+package com.auth0;
+
+import org.apache.commons.lang3.Validate;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Allows storage and retrieval/removal of cookies.
+ */
+class TransientCookieStore {
+
+    private static final int MAX_AGE_SECONDS = 600; // 10 minutes
+
+    // Prevent instantiation
+    private TransientCookieStore() {}
+
+
+    /**
+     * Stores a state value as a cookie on the response.
+     * @param response the response object to set the cookie on
+     * @param state the value for the state cookie
+     * @param sameSite the value for the SameSite attribute on the cookie
+     * @param legacySameSiteCookie whether to set a fallback cookie or not
+     */
+    static void storeState(HttpServletResponse response, String state, SameSite sameSite, boolean legacySameSiteCookie) {
+        store(response, StorageUtils.STATE_KEY, state, sameSite, legacySameSiteCookie);
+    }
+
+    /**
+     * Stores a nonce value as a cookie on the response.
+     * @param response the response object to set the cookie on
+     * @param nonce the value for the nonce cookie
+     * @param sameSite the value for the SameSite attribute on the cookie
+     * @param legacySameSiteCookie whether to set a fallback cookie or not
+     */
+    static void storeNonce(HttpServletResponse response, String nonce, SameSite sameSite, boolean legacySameSiteCookie) {
+        store(response, StorageUtils.NONCE_KEY, nonce, sameSite, legacySameSiteCookie);
+    }
+
+    /**
+     * Gets the value associated with the state cookie and removes it.
+     * @param request the request object
+     * @param response the response object
+     * @param legacySameSiteCookie whether to use a fallback cookie or not
+     * @return the value of the state cookie, if it exists
+     */
+    static String getState(HttpServletRequest request, HttpServletResponse response, boolean legacySameSiteCookie) {
+        return getOnce(StorageUtils.STATE_KEY, request, response, legacySameSiteCookie);
+    }
+
+    /**
+     * Gets the value associated with the nonce cookie and removes it.
+     * @param request the request object
+     * @param response the response object
+     * @param legacySameSiteCookie whether to use a fallback cookie or not
+     * @return the value of the nonce cookie, if it exists
+     */
+    static String getNonce(HttpServletRequest request, HttpServletResponse response, boolean legacySameSiteCookie) {
+        return getOnce(StorageUtils.NONCE_KEY, request, response, legacySameSiteCookie);
+    }
+
+    private static void store(HttpServletResponse response, String key, String value, SameSite sameSite, boolean legacySameSiteCookie) {
+        Validate.notNull(response, "response must not be null");
+        Validate.notNull(key, "key must not be null");
+        Validate.notNull(value, "value must not be null");
+        Validate.notNull(sameSite, "sameSite must not be null");
+
+        boolean sameSiteNone = SameSite.NONE == sameSite;
+
+        String cookie = String.format("%s=%s; HttpOnly; Max-Age=%d; SameSite=%s", key, value, MAX_AGE_SECONDS, sameSite.getValue());
+        if (sameSiteNone) {
+            cookie = cookie.concat("; Secure");
+        }
+
+        // Servlet Cookie API does not yet support setting the SameSite attribute, so just set cookie on header
+        response.addHeader("Set-Cookie", cookie);
+
+        // set legacy fallback cookie (if configured) for clients that won't accept SameSite=None
+        if (sameSiteNone && legacySameSiteCookie) {
+            String legacyCookie = String.format("%s=%s; HttpOnly; Max-Age=%d", "_" + key, value, MAX_AGE_SECONDS);
+            response.addHeader("Set-Cookie", legacyCookie);
+        }
+
+    }
+
+    private static String getOnce(String cookieName, HttpServletRequest request, HttpServletResponse response, boolean legacySameSiteCookie) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+
+        List<Cookie> cookiesList = Arrays.asList(cookies);
+        Cookie cookie = null;
+        for (Cookie c : cookiesList) {
+            if (cookieName.equals(c.getName())) {
+                cookie = c;
+                break;
+            }
+        }
+
+        String cookieVal = null;
+        if (cookie != null) {
+            cookieVal = cookie.getValue();
+            delete(cookie, response);
+        }
+
+        Cookie legacyCookie = null;
+        for (Cookie c : cookiesList) {
+            if (("_" + cookieName).equals(c.getName())) {
+                legacyCookie = c;
+                break;
+            }
+        }
+
+        String legacyCookieVal = null;
+        if (legacyCookie != null) {
+            legacyCookieVal = legacyCookie.getValue();
+            delete(legacyCookie, response);
+        }
+
+        return cookieVal != null ? cookieVal : legacyCookieVal;
+    }
+
+    private static void delete(Cookie cookie, HttpServletResponse response) {
+        cookie.setMaxAge(0);
+        cookie.setValue("");
+        response.addCookie(cookie);
+    }
+
+    enum SameSite {
+        LAX("Lax"),
+        NONE("None"),
+        STRICT("Strict");
+
+        private String value;
+
+        public String getValue() {
+            return this.value;
+        }
+
+        SameSite(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/src/main/java/com/auth0/TransientCookieStore.java
+++ b/src/main/java/com/auth0/TransientCookieStore.java
@@ -5,13 +5,14 @@ import org.apache.commons.lang3.Validate;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Allows storage and retrieval/removal of cookies.
  */
 class TransientCookieStore {
-
-    private static final int MAX_AGE_SECONDS = 600; // 10 minutes
 
     // Prevent instantiation
     private TransientCookieStore() {}
@@ -55,6 +56,7 @@ class TransientCookieStore {
 
     /**
      * Gets the value associated with the nonce cookie and removes it.
+     *
      * @param request the request object
      * @param response the response object
      * @param useLegacySameSiteCookie whether to use a fallback cookie or not
@@ -106,7 +108,7 @@ class TransientCookieStore {
 
         String foundCookieVal = null;
         if (foundCookie != null) {
-            foundCookieVal = foundCookie.getValue();
+            foundCookieVal = decode(foundCookie.getValue());
             delete(foundCookie, response);
         }
 
@@ -120,7 +122,7 @@ class TransientCookieStore {
 
         String foundLegacyCookieVal = null;
         if (foundLegacyCookie != null) {
-            foundLegacyCookieVal = foundLegacyCookie.getValue();
+            foundLegacyCookieVal = decode(foundLegacyCookie.getValue());
             delete(foundLegacyCookie, response);
         }
 
@@ -131,5 +133,13 @@ class TransientCookieStore {
         cookie.setMaxAge(0);
         cookie.setValue("");
         response.addCookie(cookie);
+    }
+
+    private static String decode(String valueToDecode) {
+        try {
+            return URLDecoder.decode(valueToDecode, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new AssertionError("UTF-8 character set not supported", e.getCause());
+        }
     }
 }

--- a/src/main/java/com/auth0/TransientCookieStore.java
+++ b/src/main/java/com/auth0/TransientCookieStore.java
@@ -94,41 +94,40 @@ class TransientCookieStore {
     }
 
     private static String getOnce(String cookieName, HttpServletRequest request, HttpServletResponse response, boolean useLegacySameSiteCookie) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies == null) {
+        Cookie[] requestCookies = request.getCookies();
+        if (requestCookies == null) {
             return null;
         }
-
-        List<Cookie> cookiesList = Arrays.asList(cookies);
-        Cookie cookie = null;
-        for (Cookie c : cookiesList) {
+        
+        Cookie foundCookie = null;
+        for (Cookie c : requestCookies) {
             if (cookieName.equals(c.getName())) {
-                cookie = c;
+                foundCookie = c;
                 break;
             }
         }
 
-        String cookieVal = null;
-        if (cookie != null) {
-            cookieVal = cookie.getValue();
-            delete(cookie, response);
+        String foundCookieVal = null;
+        if (foundCookie != null) {
+            foundCookieVal = foundCookie.getValue();
+            delete(foundCookie, response);
         }
 
-        Cookie legacyCookie = null;
-        for (Cookie c : cookiesList) {
+        Cookie foundLegacyCookie = null;
+        for (Cookie c : requestCookies) {
             if (("_" + cookieName).equals(c.getName())) {
-                legacyCookie = c;
+                foundLegacyCookie = c;
                 break;
             }
         }
 
-        String legacyCookieVal = null;
-        if (legacyCookie != null) {
-            legacyCookieVal = legacyCookie.getValue();
-            delete(legacyCookie, response);
+        String foundLegacyCookieVal = null;
+        if (foundLegacyCookie != null) {
+            foundLegacyCookieVal = foundLegacyCookie.getValue();
+            delete(foundLegacyCookie, response);
         }
 
-        return cookieVal != null ? cookieVal : legacyCookieVal;
+        return foundCookieVal != null ? foundCookieVal : foundLegacyCookieVal;
     }
 
     private static void delete(Cookie cookie, HttpServletResponse response) {

--- a/src/main/java/com/auth0/TransientCookieStore.java
+++ b/src/main/java/com/auth0/TransientCookieStore.java
@@ -45,6 +45,7 @@ class TransientCookieStore {
 
     /**
      * Gets the value associated with the state cookie and removes it.
+     *
      * @param request the request object
      * @param response the response object
      * @param useLegacySameSiteCookie whether to use a fallback cookie or not

--- a/src/test/java/com/auth0/AuthenticationControllerTest.java
+++ b/src/test/java/com/auth0/AuthenticationControllerTest.java
@@ -377,6 +377,7 @@ public class AuthenticationControllerTest {
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         AuthenticationController controller = AuthenticationController.newBuilder("domain", "clientId", "clientSecret")
+                .withResponseType("code")
                 .build();
 
         controller.buildAuthorizeUrl(new MockHttpServletRequest(), response, "https://redirect.uri/here")

--- a/src/test/java/com/auth0/AuthorizeUrlTest.java
+++ b/src/test/java/com/auth0/AuthorizeUrlTest.java
@@ -7,11 +7,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Collection;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
 public class AuthorizeUrlTest {
@@ -19,16 +21,19 @@ public class AuthorizeUrlTest {
     @Rule
     public ExpectedException exception = ExpectedException.none();
     private AuthAPI client;
+    private HttpServletResponse response;
+    private HttpServletRequest request;
 
     @Before
     public void setUp() {
         client = new AuthAPI("domain.auth0.com", "clientId", "clientSecret");
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
     }
 
     @Test
     public void shouldBuildValidStringUrl() {
-        HttpServletRequest req = new MockHttpServletRequest();
-        String url = new AuthorizeUrl(client, req, "https://redirect.to/me", "id_token token")
+        String url = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
                 .build();
         assertThat(url, is(notNullValue()));
         assertThat(HttpUrl.parse(url), is(notNullValue()));
@@ -36,32 +41,28 @@ public class AuthorizeUrlTest {
 
     @Test
     public void shouldSetDefaultScope() {
-        HttpServletRequest req = new MockHttpServletRequest();
-        String url = new AuthorizeUrl(client, req, "https://redirect.to/me", "id_token token")
+        String url = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
                 .build();
         assertThat(HttpUrl.parse(url).queryParameter("scope"), is("openid"));
     }
 
     @Test
     public void shouldSetResponseType() {
-        HttpServletRequest req = new MockHttpServletRequest();
-        String url = new AuthorizeUrl(client, req, "https://redirect.to/me", "id_token token")
+        String url = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
                 .build();
         assertThat(HttpUrl.parse(url).queryParameter("response_type"), is("id_token token"));
     }
 
     @Test
     public void shouldSetRedirectUrl() {
-        HttpServletRequest req = new MockHttpServletRequest();
-        String url = new AuthorizeUrl(client, req, "https://redirect.to/me", "id_token token")
+        String url = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
                 .build();
         assertThat(HttpUrl.parse(url).queryParameter("redirect_uri"), is("https://redirect.to/me"));
     }
 
     @Test
     public void shouldSetConnection() {
-        HttpServletRequest req = new MockHttpServletRequest();
-        String url = new AuthorizeUrl(client, req, "https://redirect.to/me", "id_token token")
+        String url = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
                 .withConnection("facebook")
                 .build();
         assertThat(HttpUrl.parse(url).queryParameter("connection"), is("facebook"));
@@ -69,39 +70,89 @@ public class AuthorizeUrlTest {
 
     @Test
     public void shouldSetAudience() {
-        HttpServletRequest req = new MockHttpServletRequest();
-        String url = new AuthorizeUrl(client, req, "https://redirect.to/me", "id_token token")
+        String url = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
                 .withAudience("https://api.auth0.com/")
                 .build();
         assertThat(HttpUrl.parse(url).queryParameter("audience"), is("https://api.auth0.com/"));
     }
 
     @Test
-    public void shouldSetNonceAndSaveTheValueOnTheRequestSession() {
-        HttpServletRequest req = new MockHttpServletRequest();
-        String url = new AuthorizeUrl(client, req, "https://redirect.to/me", "id_token token")
+    public void shouldSetNonceSameSiteAndLegacyCookieByDefault() {
+        String url = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
                 .withNonce("asdfghjkl")
                 .build();
         assertThat(HttpUrl.parse(url).queryParameter("nonce"), is("asdfghjkl"));
-        String savedNonce = (String) req.getSession(true).getAttribute("com.auth0.nonce");
-        assertThat(savedNonce, is("asdfghjkl"));
+
+        Collection<String> headers = response.getHeaders("Set-Cookie");
+        assertThat(headers.size(), is(2));
+        assertThat(headers, hasItem("com.auth0.nonce=asdfghjkl; HttpOnly; Max-Age=600; SameSite=None; Secure"));
+        assertThat(headers, hasItem("_com.auth0.nonce=asdfghjkl; HttpOnly; Max-Age=600"));
     }
 
     @Test
-    public void shouldSetStateAndSaveTheValueOnTheRequestSession() {
-        HttpServletRequest req = new MockHttpServletRequest();
-        String url = new AuthorizeUrl(client, req, "https://redirect.to/me", "id_token token")
+    public void shouldSetNonceSameSiteAndNotLegacyCookieWhenConfigured() {
+        String url = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
+                .withNonce("asdfghjkl")
+                .withLegacySameSiteCookie(false)
+                .build();
+        assertThat(HttpUrl.parse(url).queryParameter("nonce"), is("asdfghjkl"));
+
+        Collection<String> headers = response.getHeaders("Set-Cookie");
+        assertThat(headers.size(), is(1));
+        assertThat(headers, hasItem("com.auth0.nonce=asdfghjkl; HttpOnly; Max-Age=600; SameSite=None; Secure"));
+    }
+
+    @Test
+    public void shouldSetStateSameSiteAndLegacyCookieByDefault() {
+        String url = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
                 .withState("asdfghjkl")
                 .build();
         assertThat(HttpUrl.parse(url).queryParameter("state"), is("asdfghjkl"));
-        String savedState = (String) req.getSession(true).getAttribute("com.auth0.state");
-        assertThat(savedState, is("asdfghjkl"));
+
+        Collection<String> headers = response.getHeaders("Set-Cookie");
+        assertThat(headers.size(), is(2));
+        assertThat(headers, hasItem("com.auth0.state=asdfghjkl; HttpOnly; Max-Age=600; SameSite=None; Secure"));
+        assertThat(headers, hasItem("_com.auth0.state=asdfghjkl; HttpOnly; Max-Age=600"));
+    }
+
+    @Test
+    public void shouldSetStateSameSiteAndNotLegacyCookieWhenConfigured() {
+        String url = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
+                .withState("asdfghjkl")
+                .withLegacySameSiteCookie(false)
+                .build();
+        assertThat(HttpUrl.parse(url).queryParameter("state"), is("asdfghjkl"));
+
+        Collection<String> headers = response.getHeaders("Set-Cookie");
+        assertThat(headers.size(), is(1));
+        assertThat(headers, hasItem("com.auth0.state=asdfghjkl; HttpOnly; Max-Age=600; SameSite=None; Secure"));
+    }
+
+    @Test
+    public void shouldSetNoCookiesWhenNonceAndStateNotSet() {
+        String url = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
+                .build();
+        assertThat(HttpUrl.parse(url).queryParameter("state"), nullValue());
+        assertThat(HttpUrl.parse(url).queryParameter("nonce"), nullValue());
+
+        Collection<String> headers = response.getHeaders("Set-Cookie");
+        assertThat(headers.size(), is(0));
+    }
+
+    @Test
+    public void shouldSetNoSessionValuesWhenNonceAndStateNotSet() {
+        String url = new AuthorizeUrl(client, request, "https://redirect.to/me", "id_token token")
+                .build();
+        assertThat(HttpUrl.parse(url).queryParameter("state"), nullValue());
+        assertThat(HttpUrl.parse(url).queryParameter("nonce"), nullValue());
+
+        Collection<String> headers = response.getHeaders("Set-Cookie");
+        assertThat(headers.size(), is(0));
     }
 
     @Test
     public void shouldSetScope() {
-        HttpServletRequest req = new MockHttpServletRequest();
-        String url = new AuthorizeUrl(client, req, "https://redirect.to/me", "id_token token")
+        String url = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
                 .withScope("openid profile email")
                 .build();
         assertThat(HttpUrl.parse(url).queryParameter("scope"), is("openid profile email"));
@@ -109,8 +160,7 @@ public class AuthorizeUrlTest {
 
     @Test
     public void shouldSetCustomParameterScope() {
-        HttpServletRequest req = new MockHttpServletRequest();
-        String url = new AuthorizeUrl(client, req, "https://redirect.to/me", "id_token token")
+        String url = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
                 .withParameter("custom", "value")
                 .build();
         assertThat(HttpUrl.parse(url).queryParameter("custom"), is("value"));
@@ -120,8 +170,8 @@ public class AuthorizeUrlTest {
     public void shouldThrowWhenReusingTheInstance() {
         exception.expect(IllegalStateException.class);
         exception.expectMessage("The AuthorizeUrl instance must not be reused.");
-        HttpServletRequest req = new MockHttpServletRequest();
-        AuthorizeUrl builder = new AuthorizeUrl(client, req, "https://redirect.to/me", "id_token token");
+
+        AuthorizeUrl builder = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token");
         String firstCall = builder.build();
         assertThat(firstCall, is(notNullValue()));
         builder.build();
@@ -131,8 +181,8 @@ public class AuthorizeUrlTest {
     public void shouldThrowWhenChangingTheRedirectURI() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("Redirect URI cannot be changed once set.");
-        HttpServletRequest req = new MockHttpServletRequest();
-        new AuthorizeUrl(client, req, "https://redirect.to/me", "id_token token")
+
+        new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
                 .withParameter("redirect_uri", "new_value");
     }
 
@@ -140,8 +190,8 @@ public class AuthorizeUrlTest {
     public void shouldThrowWhenChangingTheResponseType() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("Response type cannot be changed once set.");
-        HttpServletRequest req = new MockHttpServletRequest();
-        new AuthorizeUrl(client, req, "https://redirect.to/me", "id_token token")
+
+        new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
                 .withParameter("response_type", "new_value");
     }
 
@@ -149,8 +199,8 @@ public class AuthorizeUrlTest {
     public void shouldThrowWhenChangingTheStateUsingCustomParameterSetter() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("Please, use the dedicated methods for setting the 'nonce' and 'state' parameters.");
-        HttpServletRequest req = new MockHttpServletRequest();
-        new AuthorizeUrl(client, req, "https://redirect.to/me", "id_token token")
+
+        new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
                 .withParameter("state", "new_value");
     }
 
@@ -158,8 +208,8 @@ public class AuthorizeUrlTest {
     public void shouldThrowWhenChangingTheNonceUsingCustomParameterSetter() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("Please, use the dedicated methods for setting the 'nonce' and 'state' parameters.");
-        HttpServletRequest req = new MockHttpServletRequest();
-        new AuthorizeUrl(client, req, "https://redirect.to/me", "id_token token")
+
+        new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
                 .withParameter("nonce", "new_value");
     }
 }

--- a/src/test/java/com/auth0/RandomStorageTest.java
+++ b/src/test/java/com/auth0/RandomStorageTest.java
@@ -1,19 +1,13 @@
 package com.auth0;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 public class RandomStorageTest {
-
-    @Test
-    public void shouldGetRandomString() {
-        String string = RandomStorage.secureRandomString();
-        Assert.assertThat(string, is(notNullValue()));
-    }
 
     @Test
     public void shouldSetState() {

--- a/src/test/java/com/auth0/RequestProcessorTest.java
+++ b/src/test/java/com/auth0/RequestProcessorTest.java
@@ -71,10 +71,10 @@ public class RequestProcessorTest {
 
         Map<String, Object> params = new HashMap<>();
         params.put("error", "something happened");
-        HttpServletRequest req = getRequest(params);
+        HttpServletRequest request = getRequest(params);
 
         RequestProcessor handler = new RequestProcessor(client, "code", verifyOptions);
-        handler.process(req, response);
+        handler.process(request, response);
     }
 
     @Test
@@ -86,11 +86,11 @@ public class RequestProcessorTest {
 
         Map<String, Object> params = new HashMap<>();
         params.put("state", "1234");
-        MockHttpServletRequest req = getRequest(params);
-        req.setCookies(new Cookie("com.auth0.state", "9999"));;
+        MockHttpServletRequest request = getRequest(params);
+        request.setCookies(new Cookie("com.auth0.state", "9999"));;
 
         RequestProcessor handler = new RequestProcessor(client, "code", verifyOptions);
-        handler.process(req, response);
+        handler.process(request, response);
     }
 
     @Test
@@ -102,11 +102,11 @@ public class RequestProcessorTest {
 
         Map<String, Object> params = new HashMap<>();
         params.put("state", "1234");
-        MockHttpServletRequest req = getRequest(params);
-        req.getSession().setAttribute("com.auth0.state", "9999");
+        MockHttpServletRequest request = getRequest(params);
+        request.getSession().setAttribute("com.auth0.state", "9999");
 
         RequestProcessor handler = new RequestProcessor(client, "code", verifyOptions);
-        handler.process(req, null);
+        handler.process(request, null);
     }
 
     @Test
@@ -116,11 +116,11 @@ public class RequestProcessorTest {
         exception.expect(InvalidRequestExceptionMatcher.hasDescription("The received state doesn't match the expected one."));
         exception.expectMessage("The received state doesn't match the expected one.");
 
-        MockHttpServletRequest req = getRequest(Collections.emptyMap());
-        req.setCookies(new Cookie("com.auth0.state", "1234"));
+        MockHttpServletRequest request = getRequest(Collections.emptyMap());
+        request.setCookies(new Cookie("com.auth0.state", "1234"));
 
         RequestProcessor handler = new RequestProcessor(client, "code", verifyOptions);
-        handler.process(req, response);
+        handler.process(request, response);
     }
 
     @Test
@@ -132,10 +132,10 @@ public class RequestProcessorTest {
 
         Map<String, Object> params = new HashMap<>();
         params.put("state", "1234");
-        MockHttpServletRequest req = getRequest(params);
+        MockHttpServletRequest request = getRequest(params);
 
         RequestProcessor handler = new RequestProcessor(client, "code", verifyOptions);
-        handler.process(req, response);
+        handler.process(request, response);
     }
 
     @Test
@@ -147,11 +147,11 @@ public class RequestProcessorTest {
 
         Map<String, Object> params = new HashMap<>();
         params.put("state", "1234");
-        MockHttpServletRequest req = getRequest(params);
-        req.setCookies(new Cookie("com.auth0.state", "1234"));
+        MockHttpServletRequest request = getRequest(params);
+        request.setCookies(new Cookie("com.auth0.state", "1234"));
 
         RequestProcessor handler = new RequestProcessor(client, "id_token", verifyOptions);
-        handler.process(req, response);
+        handler.process(request, response);
     }
 
     @Test
@@ -163,11 +163,11 @@ public class RequestProcessorTest {
 
         Map<String, Object> params = new HashMap<>();
         params.put("state", "1234");
-        MockHttpServletRequest req = getRequest(params);
-        req.setCookies(new Cookie("com.auth0.state", "1234"));
+        MockHttpServletRequest request = getRequest(params);
+        request.setCookies(new Cookie("com.auth0.state", "1234"));
 
         RequestProcessor handler = new RequestProcessor(client, "token", verifyOptions);
-        handler.process(req, response);
+        handler.process(request, response);
     }
 
     @Test
@@ -181,11 +181,11 @@ public class RequestProcessorTest {
         Map<String, Object> params = new HashMap<>();
         params.put("state", "1234");
         params.put("id_token", "frontIdToken");
-        MockHttpServletRequest req = getRequest(params);
-        req.setCookies(new Cookie("com.auth0.state", "1234"));
+        MockHttpServletRequest request = getRequest(params);
+        request.setCookies(new Cookie("com.auth0.state", "1234"));
 
         RequestProcessor handler = new RequestProcessor(client, "id_token", verifyOptions, tokenVerifier, true);
-        handler.process(req, response);
+        handler.process(request, response);
     }
 
     @Test
@@ -195,11 +195,11 @@ public class RequestProcessorTest {
         Map<String, Object> params = new HashMap<>();
         params.put("state", "1234");
         params.put("id_token", "frontIdToken");
-        MockHttpServletRequest req = getRequest(params);
-        req.setCookies(new Cookie("com.auth0.state", "1234"), new Cookie("com.auth0.nonce", "5678"));
+        MockHttpServletRequest request = getRequest(params);
+        request.setCookies(new Cookie("com.auth0.state", "1234"), new Cookie("com.auth0.nonce", "5678"));
 
         RequestProcessor handler = new RequestProcessor(client, "id_token", verifyOptions, tokenVerifier, true);
-        Tokens process = handler.process(req, response);
+        Tokens process = handler.process(request, response);
         assertThat(process, is(notNullValue()));
         assertThat(process.getIdToken(), is("frontIdToken"));
     }
@@ -216,11 +216,11 @@ public class RequestProcessorTest {
         params.put("code", "abc123");
         params.put("state", "1234");
         params.put("id_token", "frontIdToken");
-        MockHttpServletRequest req = getRequest(params);
-        req.setCookies(new Cookie("com.auth0.state", "1234"));
+        MockHttpServletRequest request = getRequest(params);
+        request.setCookies(new Cookie("com.auth0.state", "1234"));
 
         RequestProcessor handler = new RequestProcessor(client, "id_token code", verifyOptions, tokenVerifier, true);
-        handler.process(req, response);
+        handler.process(request, response);
     }
 
     @Test
@@ -233,15 +233,15 @@ public class RequestProcessorTest {
         Map<String, Object> params = new HashMap<>();
         params.put("code", "abc123");
         params.put("state", "1234");
-        MockHttpServletRequest req = getRequest(params);
-        req.setCookies(new Cookie("com.auth0.state", "1234"));
+        MockHttpServletRequest request = getRequest(params);
+        request.setCookies(new Cookie("com.auth0.state", "1234"));
 
         AuthRequest codeExchangeRequest = mock(AuthRequest.class);
         when(codeExchangeRequest.execute()).thenThrow(Auth0Exception.class);
         when(client.exchangeCode("abc123", "https://me.auth0.com:80/callback")).thenReturn(codeExchangeRequest);
 
         RequestProcessor handler = new RequestProcessor(client, "code", verifyOptions, tokenVerifier, true);
-        handler.process(req, response);
+        handler.process(request, response);
     }
 
     @Test
@@ -255,8 +255,8 @@ public class RequestProcessorTest {
         Map<String, Object> params = new HashMap<>();
         params.put("code", "abc123");
         params.put("state", "1234");
-        MockHttpServletRequest req = getRequest(params);
-        req.setCookies(new Cookie("com.auth0.state", "1234"));
+        MockHttpServletRequest request = getRequest(params);
+        request.setCookies(new Cookie("com.auth0.state", "1234"));
 
         AuthRequest codeExchangeRequest = mock(AuthRequest.class);
         TokenHolder tokenHolder = mock(TokenHolder.class);
@@ -265,7 +265,7 @@ public class RequestProcessorTest {
         when(client.exchangeCode("abc123", "https://me.auth0.com:80/callback")).thenReturn(codeExchangeRequest);
 
         RequestProcessor handler = new RequestProcessor(client, "code", verifyOptions, tokenVerifier, true);
-        handler.process(req, response);
+        handler.process(request, response);
     }
 
     @Test
@@ -278,8 +278,8 @@ public class RequestProcessorTest {
         params.put("id_token", "frontIdToken");
         params.put("expires_in", "8400");
         params.put("token_type", "frontTokenType");
-        MockHttpServletRequest req = getRequest(params);
-        req.setCookies(new Cookie("com.auth0.state", "1234"));
+        MockHttpServletRequest request = getRequest(params);
+        request.setCookies(new Cookie("com.auth0.state", "1234"));
 
         AuthRequest codeExchangeRequest = mock(AuthRequest.class);
         TokenHolder tokenHolder = mock(TokenHolder.class);
@@ -290,7 +290,7 @@ public class RequestProcessorTest {
         when(client.exchangeCode("abc123", "https://me.auth0.com:80/callback")).thenReturn(codeExchangeRequest);
 
         RequestProcessor handler = new RequestProcessor(client, "id_token code", verifyOptions, tokenVerifier, true);
-        Tokens tokens = handler.process(req, response);
+        Tokens tokens = handler.process(request, response);
 
         //Should not verify the ID Token twice
         verify(tokenVerifier).verify("frontIdToken", verifyOptions);
@@ -314,8 +314,8 @@ public class RequestProcessorTest {
         params.put("access_token", "frontAccessToken");
         params.put("expires_in", "8400");
         params.put("token_type", "frontTokenType");
-        MockHttpServletRequest req = getRequest(params);
-        req.setCookies(new Cookie("com.auth0.state", "1234"));
+        MockHttpServletRequest request = getRequest(params);
+        request.setCookies(new Cookie("com.auth0.state", "1234"));
 
         AuthRequest codeExchangeRequest = mock(AuthRequest.class);
         TokenHolder tokenHolder = mock(TokenHolder.class);
@@ -328,7 +328,7 @@ public class RequestProcessorTest {
         when(client.exchangeCode("abc123", "https://me.auth0.com:80/callback")).thenReturn(codeExchangeRequest);
 
         RequestProcessor handler = new RequestProcessor(client, "id_token token code", verifyOptions, tokenVerifier, true);
-        Tokens tokens = handler.process(req, response);
+        Tokens tokens = handler.process(request, response);
 
         //Should not verify the ID Token twice
         verify(tokenVerifier).verify("frontIdToken", verifyOptions);
@@ -350,8 +350,8 @@ public class RequestProcessorTest {
         Map<String, Object> params = new HashMap<>();
         params.put("code", "abc123");
         params.put("state", "1234");
-        MockHttpServletRequest req = getRequest(params);
-        req.setCookies(new Cookie("com.auth0.state", "1234"));
+        MockHttpServletRequest request = getRequest(params);
+        request.setCookies(new Cookie("com.auth0.state", "1234"));
 
         AuthRequest codeExchangeRequest = mock(AuthRequest.class);
         TokenHolder tokenHolder = mock(TokenHolder.class);
@@ -362,7 +362,7 @@ public class RequestProcessorTest {
         when(client.exchangeCode("abc123", "https://me.auth0.com:80/callback")).thenReturn(codeExchangeRequest);
 
         RequestProcessor handler = new RequestProcessor(client, "code", verifyOptions, tokenVerifier, true);
-        Tokens tokens = handler.process(req, response);
+        Tokens tokens = handler.process(request, response);
 
         verify(tokenVerifier).verify("backIdToken", verifyOptions);
         verifyNoMoreInteractions(tokenVerifier);
@@ -378,8 +378,8 @@ public class RequestProcessorTest {
         Map<String, Object> params = new HashMap<>();
         params.put("code", "abc123");
         params.put("state", "1234");
-        MockHttpServletRequest req = getRequest(params);
-        req.setCookies(new Cookie("com.auth0.state", "1234"));
+        MockHttpServletRequest request = getRequest(params);
+        request.setCookies(new Cookie("com.auth0.state", "1234"));
 
         AuthRequest codeExchangeRequest = mock(AuthRequest.class);
         TokenHolder tokenHolder = mock(TokenHolder.class);
@@ -387,7 +387,7 @@ public class RequestProcessorTest {
         when(client.exchangeCode("abc123", "https://me.auth0.com:80/callback")).thenReturn(codeExchangeRequest);
 
         RequestProcessor handler = new RequestProcessor(client, "code", verifyOptions, tokenVerifier, true);
-        Tokens tokens = handler.process(req, response);
+        Tokens tokens = handler.process(request, response);
 
         verifyNoMoreInteractions(tokenVerifier);
 
@@ -404,8 +404,8 @@ public class RequestProcessorTest {
         SignatureVerifier signatureVerifier = mock(SignatureVerifier.class);
         IdTokenVerifier.Options verifyOptions = new IdTokenVerifier.Options("issuer", "audience", signatureVerifier);
         RequestProcessor handler = new RequestProcessor(client, "code", verifyOptions);
-        HttpServletRequest req = new MockHttpServletRequest();
-        AuthorizeUrl builder = handler.buildAuthorizeUrl(req, response,"https://redirect.uri/here", "state", "nonce");
+        HttpServletRequest request = new MockHttpServletRequest();
+        AuthorizeUrl builder = handler.buildAuthorizeUrl(request, response,"https://redirect.uri/here", "state", "nonce");
         String authorizeUrl = builder.build();
 
         assertThat(authorizeUrl, is(notNullValue()));
@@ -425,8 +425,8 @@ public class RequestProcessorTest {
         AuthAPI client = new AuthAPI("me.auth0.com", "clientId", "clientSecret");
         when(verifyOptions.getMaxAge()).thenReturn(906030);
         RequestProcessor handler = new RequestProcessor(client, "code", verifyOptions);
-        HttpServletRequest req = new MockHttpServletRequest();
-        AuthorizeUrl builder = handler.buildAuthorizeUrl(req, response,"https://redirect.uri/here", "state", "nonce");
+        HttpServletRequest request = new MockHttpServletRequest();
+        AuthorizeUrl builder = handler.buildAuthorizeUrl(request, response,"https://redirect.uri/here", "state", "nonce");
         String authorizeUrl = builder.build();
 
         assertThat(authorizeUrl, is(notNullValue()));
@@ -437,8 +437,8 @@ public class RequestProcessorTest {
     public void shouldNotSetNonceIfRequestTypeIsNotIdToken() {
         AuthAPI client = new AuthAPI("me.auth0.com", "clientId", "clientSecret");
         RequestProcessor handler = new RequestProcessor(client, "code", verifyOptions);
-        HttpServletRequest req = new MockHttpServletRequest();
-        AuthorizeUrl builder = handler.buildAuthorizeUrl(req, response,"https://redirect.uri/here", "state", "nonce");
+        HttpServletRequest request = new MockHttpServletRequest();
+        AuthorizeUrl builder = handler.buildAuthorizeUrl(request, response,"https://redirect.uri/here", "state", "nonce");
         String authorizeUrl = builder.build();
 
         assertThat(authorizeUrl, is(notNullValue()));
@@ -449,8 +449,8 @@ public class RequestProcessorTest {
     public void shouldSetNonceIfRequestTypeIsIdToken() {
         AuthAPI client = new AuthAPI("me.auth0.com", "clientId", "clientSecret");
         RequestProcessor handler = new RequestProcessor(client, "id_token", verifyOptions);
-        HttpServletRequest req = new MockHttpServletRequest();
-        AuthorizeUrl builder = handler.buildAuthorizeUrl(req, response,"https://redirect.uri/here", "state", "nonce");
+        HttpServletRequest request = new MockHttpServletRequest();
+        AuthorizeUrl builder = handler.buildAuthorizeUrl(request, response,"https://redirect.uri/here", "state", "nonce");
         String authorizeUrl = builder.build();
 
         assertThat(authorizeUrl, is(notNullValue()));
@@ -461,8 +461,8 @@ public class RequestProcessorTest {
     public void shouldNotSetNullNonceIfRequestTypeIsIdToken() {
         AuthAPI client = new AuthAPI("me.auth0.com", "clientId", "clientSecret");
         RequestProcessor handler = new RequestProcessor(client, "id_token", verifyOptions);
-        HttpServletRequest req = new MockHttpServletRequest();
-        AuthorizeUrl builder = handler.buildAuthorizeUrl(req, response,"https://redirect.uri/here", "state", null);
+        HttpServletRequest request = new MockHttpServletRequest();
+        AuthorizeUrl builder = handler.buildAuthorizeUrl(request, response,"https://redirect.uri/here", "state", null);
         String authorizeUrl = builder.build();
 
         assertThat(authorizeUrl, is(notNullValue()));
@@ -473,8 +473,8 @@ public class RequestProcessorTest {
     public void shouldBuildAuthorizeUrlWithNonceAndFormPostIfResponseTypeIsIdToken() {
         AuthAPI client = new AuthAPI("me.auth0.com", "clientId", "clientSecret");
         RequestProcessor handler = new RequestProcessor(client, "id_token", verifyOptions);
-        HttpServletRequest req = new MockHttpServletRequest();
-        AuthorizeUrl builder = handler.buildAuthorizeUrl(req, response,"https://redirect.uri/here", "state", "nonce");
+        HttpServletRequest request = new MockHttpServletRequest();
+        AuthorizeUrl builder = handler.buildAuthorizeUrl(request, response,"https://redirect.uri/here", "state", "nonce");
         String authorizeUrl = builder.build();
 
         assertThat(authorizeUrl, is(notNullValue()));
@@ -492,8 +492,8 @@ public class RequestProcessorTest {
     public void shouldBuildAuthorizeUrlWithFormPostIfResponseTypeIsToken() {
         AuthAPI client = new AuthAPI("me.auth0.com", "clientId", "clientSecret");
         RequestProcessor handler = new RequestProcessor(client, "token", verifyOptions);
-        HttpServletRequest req = new MockHttpServletRequest();
-        AuthorizeUrl builder = handler.buildAuthorizeUrl(req, response, "https://redirect.uri/here", "state", "nonce");
+        HttpServletRequest request = new MockHttpServletRequest();
+        AuthorizeUrl builder = handler.buildAuthorizeUrl(request, response, "https://redirect.uri/here", "state", "nonce");
         String authorizeUrl = builder.build();
 
         assertThat(authorizeUrl, is(notNullValue()));

--- a/src/test/java/com/auth0/TransientCookieStoreTest.java
+++ b/src/test/java/com/auth0/TransientCookieStoreTest.java
@@ -28,7 +28,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldNotSetCookieIfStateIsNull() {
-        TransientCookieStore.storeState(response, null, TransientCookieStore.SameSite.NONE, true);
+        TransientCookieStore.storeState(response, null, SameSite.NONE, true);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(0));
@@ -36,7 +36,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldNotSetCookieIfNonceIsNull() {
-        TransientCookieStore.storeNonce(response, null, TransientCookieStore.SameSite.NONE, true);
+        TransientCookieStore.storeNonce(response, null, SameSite.NONE, true);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(0));
@@ -44,7 +44,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldSetStateSameSiteCookieAndFallbackCookie() {
-        TransientCookieStore.storeState(response, "123456", TransientCookieStore.SameSite.NONE, true);
+        TransientCookieStore.storeState(response, "123456", SameSite.NONE, true);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
@@ -55,7 +55,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldSetStateSameSiteCookieAndNoFallbackCookie() {
-        TransientCookieStore.storeState(response, "123456", TransientCookieStore.SameSite.NONE, false);
+        TransientCookieStore.storeState(response, "123456", SameSite.NONE, false);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));
@@ -65,7 +65,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldSetNonceSameSiteCookieAndFallbackCookie() {
-        TransientCookieStore.storeNonce(response, "123456", TransientCookieStore.SameSite.NONE, true);
+        TransientCookieStore.storeNonce(response, "123456", SameSite.NONE, true);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
@@ -76,7 +76,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldSetNonceSameSiteCookieAndNoFallbackCookie() {
-        TransientCookieStore.storeNonce(response, "123456", TransientCookieStore.SameSite.NONE, false);
+        TransientCookieStore.storeNonce(response, "123456", SameSite.NONE, false);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));

--- a/src/test/java/com/auth0/TransientCookieStoreTest.java
+++ b/src/test/java/com/auth0/TransientCookieStoreTest.java
@@ -1,0 +1,217 @@
+package com.auth0;
+
+import org.hamcrest.beans.HasPropertyWithValue;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.http.Cookie;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+public class TransientCookieStoreTest {
+
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @Before
+    public void setup() {
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+    }
+
+    @Test
+    public void shouldSetStateSameSiteCookieAndFallbackCookie() {
+        TransientCookieStore.storeState(response, "123456", TransientCookieStore.SameSite.NONE, true);
+
+        List<String> headers = response.getHeaders("Set-Cookie");
+        assertThat(headers.size(), is(2));
+
+        assertThat(headers, hasItem("com.auth0.state=123456; HttpOnly; Max-Age=600; SameSite=None; Secure"));
+        assertThat(headers, hasItem("_com.auth0.state=123456; HttpOnly; Max-Age=600"));
+    }
+
+    @Test
+    public void shouldSetStateSameSiteCookieAndNoFallbackCookie() {
+        TransientCookieStore.storeState(response, "123456", TransientCookieStore.SameSite.NONE, false);
+
+        List<String> headers = response.getHeaders("Set-Cookie");
+        assertThat(headers.size(), is(1));
+
+        assertThat(headers, hasItem("com.auth0.state=123456; HttpOnly; Max-Age=600; SameSite=None; Secure"));
+    }
+
+    @Test
+    public void shouldSetNonceSameSiteCookieAndFallbackCookie() {
+        TransientCookieStore.storeNonce(response, "123456", TransientCookieStore.SameSite.NONE, true);
+
+        List<String> headers = response.getHeaders("Set-Cookie");
+        assertThat(headers.size(), is(2));
+
+        assertThat(headers, hasItem("com.auth0.nonce=123456; HttpOnly; Max-Age=600; SameSite=None; Secure"));
+        assertThat(headers, hasItem("_com.auth0.nonce=123456; HttpOnly; Max-Age=600"));
+    }
+
+    @Test
+    public void shouldSetNonceSameSiteCookieAndNoFallbackCookie() {
+        TransientCookieStore.storeNonce(response, "123456", TransientCookieStore.SameSite.NONE, false);
+
+        List<String> headers = response.getHeaders("Set-Cookie");
+        assertThat(headers.size(), is(1));
+
+        assertThat(headers, hasItem("com.auth0.nonce=123456; HttpOnly; Max-Age=600; SameSite=None; Secure"));
+    }
+
+    @Test
+    public void shouldRemoveStateSameSiteCookieAndFallbackCookie() {
+        Cookie cookie1 = new Cookie("com.auth0.state", "123456");
+        Cookie cookie2 = new Cookie("_com.auth0.state", "123456");
+
+        request.setCookies(cookie1, cookie2);
+
+        String state = TransientCookieStore.getState(request, response, true);
+        assertThat(state, is("123456"));
+
+        Cookie[] cookies = response.getCookies();
+        assertThat(cookies, is(notNullValue()));
+
+        List<Cookie> cookieList = Arrays.asList(cookies);
+        assertThat(cookieList.size(), is(2));
+
+        assertThat(Arrays.asList(cookies), everyItem(HasPropertyWithValue.hasProperty("value", is(""))));
+        assertThat(Arrays.asList(cookies), everyItem(HasPropertyWithValue.hasProperty("maxAge", is(0))));
+    }
+
+    @Test
+    public void shouldRemoveStateSameSiteCookie() {
+        Cookie cookie1 = new Cookie("com.auth0.state", "123456");
+
+        request.setCookies(cookie1);
+
+        String state = TransientCookieStore.getState(request, response, false);
+        assertThat(state, is("123456"));
+
+        Cookie[] cookies = response.getCookies();
+        assertThat(cookies, is(notNullValue()));
+
+        List<Cookie> cookieList = Arrays.asList(cookies);
+        assertThat(cookieList.size(), is(1));
+        assertThat(Arrays.asList(cookies), everyItem(HasPropertyWithValue.hasProperty("value", is(""))));
+        assertThat(Arrays.asList(cookies), everyItem(HasPropertyWithValue.hasProperty("maxAge", is(0))));
+    }
+
+    @Test
+    public void shouldRemoveStateFallbackCookie() {
+        Cookie cookie1 = new Cookie("_com.auth0.state", "123456");
+
+        request.setCookies(cookie1);
+
+        String state = TransientCookieStore.getState(request, response, true);
+        assertThat(state, is("123456"));
+
+        Cookie[] cookies = response.getCookies();
+        assertThat(cookies, is(notNullValue()));
+
+        List<Cookie> cookieList = Arrays.asList(cookies);
+        assertThat(cookieList.size(), is(1));
+        assertThat(Arrays.asList(cookies), everyItem(HasPropertyWithValue.hasProperty("value", is(""))));
+        assertThat(Arrays.asList(cookies), everyItem(HasPropertyWithValue.hasProperty("maxAge", is(0))));
+    }
+
+    @Test
+    public void shouldRemoveNonceSameSiteCookieAndFallbackCookie() {
+        Cookie cookie1 = new Cookie("com.auth0.nonce", "123456");
+        Cookie cookie2 = new Cookie("_com.auth0.nonce", "123456");
+
+        request.setCookies(cookie1, cookie2);
+
+        String state = TransientCookieStore.getNonce(request, response, true);
+        assertThat(state, is("123456"));
+
+        Cookie[] cookies = response.getCookies();
+        assertThat(cookies, is(notNullValue()));
+
+        List<Cookie> cookieList = Arrays.asList(cookies);
+        assertThat(cookieList.size(), is(2));
+        assertThat(Arrays.asList(cookies), everyItem(HasPropertyWithValue.hasProperty("value", is(""))));
+        assertThat(Arrays.asList(cookies), everyItem(HasPropertyWithValue.hasProperty("maxAge", is(0))));
+    }
+
+    @Test
+    public void shouldRemoveNonceSameSiteCookie() {
+        Cookie cookie1 = new Cookie("com.auth0.nonce", "123456");
+
+        request.setCookies(cookie1);
+
+        String state = TransientCookieStore.getNonce(request, response, true);
+        assertThat(state, is("123456"));
+
+        Cookie[] cookies = response.getCookies();
+        assertThat(cookies, is(notNullValue()));
+
+        List<Cookie> cookieList = Arrays.asList(cookies);
+        assertThat(cookieList.size(), is(1));
+        assertThat(Arrays.asList(cookies), everyItem(HasPropertyWithValue.hasProperty("value", is(""))));
+        assertThat(Arrays.asList(cookies), everyItem(HasPropertyWithValue.hasProperty("maxAge", is(0))));
+    }
+
+    @Test
+    public void shouldRemoveNonceFallbackCookie() {
+        Cookie cookie1 = new Cookie("_com.auth0.nonce", "123456");
+
+        request.setCookies(cookie1);
+
+        String state = TransientCookieStore.getNonce(request, response, true);
+        assertThat(state, is("123456"));
+
+        Cookie[] cookies = response.getCookies();
+        assertThat(cookies, is(notNullValue()));
+
+        List<Cookie> cookieList = Arrays.asList(cookies);
+        assertThat(cookieList.size(), is(1));
+        assertThat(Arrays.asList(cookies), everyItem(HasPropertyWithValue.hasProperty("value", is(""))));
+        assertThat(Arrays.asList(cookies), everyItem(HasPropertyWithValue.hasProperty("maxAge", is(0))));
+    }
+
+    @Test
+    public void shouldReturnEmptyStateWhenNoCookies() {
+        String state = TransientCookieStore.getState(request, response, true);
+        assertThat(state, is(nullValue()));
+    }
+
+    @Test
+    public void shouldReturnEmptyNonceWhenNoCookies() {
+        String nonce = TransientCookieStore.getNonce(request, response, true);
+        assertThat(nonce, is(nullValue()));
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenNoStateCookie() {
+        Cookie cookie1 = new Cookie("someCookie", "123456");
+        request.setCookies(cookie1);
+
+        String state = TransientCookieStore.getState(request, response, true);
+        assertThat(state, is(nullValue()));
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenNoNonceCookie() {
+        Cookie cookie1 = new Cookie("someCookie", "123456");
+        request.setCookies(cookie1);
+
+        String nonce = TransientCookieStore.getNonce(request, response, true);
+        assertThat(nonce, is(nullValue()));
+        assertThat(nonce, is(nullValue()));
+    }
+
+//    @Test
+//    public void shouldStoreInSessionIfResponseIsNull() {
+//        TransientCookieStore.storeState(request, response, "123456", null, false);
+//    }
+}

--- a/src/test/java/com/auth0/TransientCookieStoreTest.java
+++ b/src/test/java/com/auth0/TransientCookieStoreTest.java
@@ -27,6 +27,22 @@ public class TransientCookieStoreTest {
     }
 
     @Test
+    public void shouldNotSetCookieIfStateIsNull() {
+        TransientCookieStore.storeState(response, null, TransientCookieStore.SameSite.NONE, true);
+
+        List<String> headers = response.getHeaders("Set-Cookie");
+        assertThat(headers.size(), is(0));
+    }
+
+    @Test
+    public void shouldNotSetCookieIfNonceIsNull() {
+        TransientCookieStore.storeNonce(response, null, TransientCookieStore.SameSite.NONE, true);
+
+        List<String> headers = response.getHeaders("Set-Cookie");
+        assertThat(headers.size(), is(0));
+    }
+
+    @Test
     public void shouldSetStateSameSiteCookieAndFallbackCookie() {
         TransientCookieStore.storeState(response, "123456", TransientCookieStore.SameSite.NONE, true);
 
@@ -209,9 +225,4 @@ public class TransientCookieStoreTest {
         assertThat(nonce, is(nullValue()));
         assertThat(nonce, is(nullValue()));
     }
-
-//    @Test
-//    public void shouldStoreInSessionIfResponseIsNull() {
-//        TransientCookieStore.storeState(request, response, "123456", null, false);
-//    }
 }


### PR DESCRIPTION
### Changes

Adds support for SameSite cookie handling.

* Sets the SameSite attribute to "None" if using `form_post` response mode
* Sets a fallback cookie for clients that do not accept SameSite=None yet. Can be turned off by configuration on the `AuthenticationController`

Includes new methods that will store state and nonce in cookies (using session as fallback):
* `AuthenticationController.buildAuthorizeUrl(HttpServletRequest request, HttpServletResponse response, String redirectUri)`
* `AuthenticationController.handle(HttpServletRequest request, HttpServletResponse response)`
* `AuthorizeUrl(AuthAPI client, HttpServletRequest request, HttpServletResponse response, String redirectUrl, String responseType)`

A future PR will add deprecations of the corresponding methods:
* `AuthenticationController.buildAuthorizeUrl(HttpServletRequest request, String redirectUri)`
* `AuthenticationController.handle(HttpServletRequest request)`
* `AuthorizeUrl(AuthAPI client, HttpServletRequest request, String redirectUrl, String responseType)`

In order to prevent issues if a developer uses the deprecated `buildAuthorizeUrl` and new `handle` methods (or vice versa), values will be stored in the Session as a fallback.

### References

[Web.dev: SameSite cookies explained](https://web.dev/samesite-cookies-explained/)

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
