### PR TITLE
Allow cookies to always have the Secure attribute if configured

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,24 +5,6 @@
 # Tomcat
 target
 
-# User-specific stuff:
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/.name
-
-# Sensitive or high-churn files:
-.idea/dataSources/
-.idea/dataSources.ids
-.idea/dataSources.xml
-.idea/dataSources.local.xml
-.idea/sqlDataSources.xml
-.idea/dynamic.xml
-.idea/uiDesigner.xml
-
-# Gradle:
-.idea/gradle.xml
-.idea/libraries
-
 # Mongo Explorer plugin:
 .idea/mongoSettings.xml
 
@@ -33,6 +15,7 @@ target
 
 # IntelliJ
 /out/
+.idea/
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/

--- a/src/main/java/com/auth0/AuthorizeUrl.java
+++ b/src/main/java/com/auth0/AuthorizeUrl.java
@@ -23,6 +23,7 @@ public class AuthorizeUrl {
     private final AuthorizeUrlBuilder builder;
     private final String responseType;
     private boolean useLegacySameSiteCookie = true;
+    private boolean setSecureCookie = false;
     private String nonce;
     private String state;
 
@@ -59,6 +60,23 @@ public class AuthorizeUrl {
      */
     public AuthorizeUrl withConnection(String connection) {
         builder.withConnection(connection);
+        return this;
+    }
+
+    /**
+     * Sets whether cookies used during the authentication flow have the {@code Secure} attribute set or not.
+     * By default, cookies will be set with the Secure attribute if the responseType includes {@code id_token} and thus requires
+     * the {@code SameSite=None} cookie attribute to set. Setting this to false will <strong>not</strong> override this behavior,
+     * as clients will reject cookies with {@code SameSite=None} unless the {@code Secure} attribute is set.
+     *
+     * While not guaranteed by all clients, generally a cookie with the {@code Secure} attribute will be rejected unless
+     * served over HTTPS.
+     *
+     * @param secureCookie whether to always set the Secure attribute on all cookies.
+     * @return the builder instance.
+     */
+    public AuthorizeUrl withSecureCookie(boolean secureCookie) {
+        this.setSecureCookie = secureCookie;
         return this;
     }
 
@@ -156,8 +174,8 @@ public class AuthorizeUrl {
         if (response != null) {
             SameSite sameSiteValue = containsFormPost() ? SameSite.NONE : SameSite.LAX;
 
-            TransientCookieStore.storeState(response, state, sameSiteValue, useLegacySameSiteCookie);
-            TransientCookieStore.storeNonce(response, nonce, sameSiteValue, useLegacySameSiteCookie);
+            TransientCookieStore.storeState(response, state, sameSiteValue, useLegacySameSiteCookie, setSecureCookie);
+            TransientCookieStore.storeNonce(response, nonce, sameSiteValue, useLegacySameSiteCookie, setSecureCookie);
         }
 
         // Also store in Session just in case developer uses deprecated

--- a/src/main/java/com/auth0/AuthorizeUrl.java
+++ b/src/main/java/com/auth0/AuthorizeUrl.java
@@ -66,7 +66,7 @@ public class AuthorizeUrl {
     /**
      * Sets whether cookies used during the authentication flow have the {@code Secure} attribute set or not.
      * By default, cookies will be set with the Secure attribute if the responseType includes {@code id_token} and thus requires
-     * the {@code SameSite=None} cookie attribute to set. Setting this to false will <strong>not</strong> override this behavior,
+     * the {@code SameSite=None} cookie attribute set. Setting this to false will <strong>not</strong> override this behavior,
      * as clients will reject cookies with {@code SameSite=None} unless the {@code Secure} attribute is set.
      *
      * While not guaranteed by all clients, generally a cookie with the {@code Secure} attribute will be rejected unless

--- a/src/test/java/com/auth0/AuthorizeUrlTest.java
+++ b/src/test/java/com/auth0/AuthorizeUrlTest.java
@@ -129,7 +129,7 @@ public class AuthorizeUrlTest {
     }
 
     @Test
-    public void shouldSetSecureCookieWhenConfigured() {
+    public void shouldSetSecureCookieWhenConfiguredTrue() {
         String url = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "code")
                 .withState("asdfghjkl")
                 .withSecureCookie(true)
@@ -139,6 +139,20 @@ public class AuthorizeUrlTest {
         Collection<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));
         assertThat(headers, hasItem("com.auth0.state=asdfghjkl; HttpOnly; Max-Age=600; SameSite=Lax; Secure"));
+    }
+
+    @Test
+    public void shouldSetSecureCookieWhenConfiguredFalseAndSameSiteNone() {
+        String url = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token")
+                .withState("asdfghjkl")
+                .withSecureCookie(false)
+                .build();
+        assertThat(HttpUrl.parse(url).queryParameter("state"), is("asdfghjkl"));
+
+        Collection<String> headers = response.getHeaders("Set-Cookie");
+        assertThat(headers.size(), is(2));
+        assertThat(headers, hasItem("com.auth0.state=asdfghjkl; HttpOnly; Max-Age=600; SameSite=None; Secure"));
+        assertThat(headers, hasItem("_com.auth0.state=asdfghjkl; HttpOnly; Max-Age=600"));
     }
 
     @Test

--- a/src/test/java/com/auth0/AuthorizeUrlTest.java
+++ b/src/test/java/com/auth0/AuthorizeUrlTest.java
@@ -129,6 +129,19 @@ public class AuthorizeUrlTest {
     }
 
     @Test
+    public void shouldSetSecureCookieWhenConfigured() {
+        String url = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "code")
+                .withState("asdfghjkl")
+                .withSecureCookie(true)
+                .build();
+        assertThat(HttpUrl.parse(url).queryParameter("state"), is("asdfghjkl"));
+
+        Collection<String> headers = response.getHeaders("Set-Cookie");
+        assertThat(headers.size(), is(1));
+        assertThat(headers, hasItem("com.auth0.state=asdfghjkl; HttpOnly; Max-Age=600; SameSite=Lax; Secure"));
+    }
+
+    @Test
     public void shouldSetNoCookiesWhenNonceAndStateNotSet() {
         String url = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
                 .build();

--- a/src/test/java/com/auth0/TransientCookieStoreTest.java
+++ b/src/test/java/com/auth0/TransientCookieStoreTest.java
@@ -27,7 +27,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldNotSetCookieIfStateIsNull() {
-        TransientCookieStore.storeState(response, null, SameSite.NONE, true);
+        TransientCookieStore.storeState(response, null, SameSite.NONE, true, false);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(0));
@@ -35,7 +35,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldNotSetCookieIfNonceIsNull() {
-        TransientCookieStore.storeNonce(response, null, SameSite.NONE, true);
+        TransientCookieStore.storeNonce(response, null, SameSite.NONE, true, false);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(0));
@@ -44,7 +44,7 @@ public class TransientCookieStoreTest {
     @Test
     public void shouldHandleSpecialCharsWhenStoringState() throws Exception {
         String stateVal = ";state = ,va\\lu;e\"";
-        TransientCookieStore.storeState(response, stateVal, SameSite.NONE, true);
+        TransientCookieStore.storeState(response, stateVal, SameSite.NONE, true, false);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
@@ -60,7 +60,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldSetStateSameSiteCookieAndFallbackCookie() {
-        TransientCookieStore.storeState(response, "123456", SameSite.NONE, true);
+        TransientCookieStore.storeState(response, "123456", SameSite.NONE, true, false);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
@@ -71,7 +71,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldSetStateSameSiteCookieAndNoFallbackCookie() {
-        TransientCookieStore.storeState(response, "123456", SameSite.NONE, false);
+        TransientCookieStore.storeState(response, "123456", SameSite.NONE, false, false);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));
@@ -80,8 +80,39 @@ public class TransientCookieStoreTest {
     }
 
     @Test
+    public void shouldSetSecureCookieWhenSameSiteLaxAndConfigured() {
+        TransientCookieStore.storeState(response, "123456", SameSite.LAX, true, true);
+
+        List<String> headers = response.getHeaders("Set-Cookie");
+        assertThat(headers.size(), is(1));
+
+        assertThat(headers, hasItem("com.auth0.state=123456; HttpOnly; Max-Age=600; SameSite=Lax; Secure"));
+    }
+
+    @Test
+    public void shouldSetSecureFallbackCookieWhenSameSiteNoneAndConfigured() {
+        TransientCookieStore.storeState(response, "123456", SameSite.NONE, true, true);
+
+        List<String> headers = response.getHeaders("Set-Cookie");
+        assertThat(headers.size(), is(2));
+
+        assertThat(headers, hasItem("com.auth0.state=123456; HttpOnly; Max-Age=600; SameSite=None; Secure"));
+        assertThat(headers, hasItem("_com.auth0.state=123456; HttpOnly; Max-Age=600; Secure"));
+    }
+
+    @Test
+    public void shouldNotSetSecureCookieWhenSameSiteLaxAndConfigured() {
+        TransientCookieStore.storeState(response, "123456", SameSite.LAX, true, false);
+
+        List<String> headers = response.getHeaders("Set-Cookie");
+        assertThat(headers.size(), is(1));
+
+        assertThat(headers, hasItem("com.auth0.state=123456; HttpOnly; Max-Age=600; SameSite=Lax"));
+    }
+
+    @Test
     public void shouldSetNonceSameSiteCookieAndFallbackCookie() {
-        TransientCookieStore.storeNonce(response, "123456", SameSite.NONE, true);
+        TransientCookieStore.storeNonce(response, "123456", SameSite.NONE, true, false);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
@@ -92,7 +123,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldSetNonceSameSiteCookieAndNoFallbackCookie() {
-        TransientCookieStore.storeNonce(response, "123456", SameSite.NONE, false);
+        TransientCookieStore.storeNonce(response, "123456", SameSite.NONE, false, false);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));


### PR DESCRIPTION
### Changes

Currently, cookies used for the `state` and `nonce` during the authentication flow only set the `Secure` attribute if `SameSite=None` (this happens if the response type includes `id_token`). This change allows configuration to always set the `Secure` attribute, regardless of the SameSite value.

### References

Closes #58 

### Testing

- [X] This change adds test coverage
- [ ] This change has been tested on the latest version of Java or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
