### PR TITLE
Remove link to removed Spring Quickstart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,9 @@
 
 A Java Jar library that makes easier to integrate Auth0 Authentication on MVC applications.
 
-A few samples are available demonstrating the usage with _Java Servlets_ and _Spring_:
+See the [Java Servlet Quickstart](https://auth0.com/docs/quickstart/webapp/java) to learn how to use this library in a Servlet application.
 
-[Java Servlets](https://auth0.com/docs/quickstart/webapp/java)
-
-[Spring](https://auth0.com/docs/quickstart/webapp/java-spring-mvc)
-
+> If you are using Spring Boot 2, it is recommended to use the OIDC support available in Spring, instead of using this library. See the [Spring Boot Quickstart](https://auth0.com/docs/quickstart/webapp/java-spring-boot) for more information.
 
 ## Download
 


### PR DESCRIPTION
### Changes

Removes the (broken) link to the now removed Spring 4 Quickstart. Add note to see the Spring Boot Quickstart if using Spring Boot 2.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
