### PR TITLE
Add support for Organizations feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,45 @@ AuthenticationController authController = AuthenticationController.newBuilder("d
     .build();
 ```
 
+### Organizations (Closed Beta)
+
+Organizations is a set of features that provide better support for developers who build and maintain SaaS and Business-to-Business (B2B) applications.
+
+Using Organizations, you can:
+
+- Represent teams, business customers, partner companies, or any logical grouping of users that should have different ways of accessing your applications, as organizations.
+- Manage their membership in a variety of ways, including user invitation.
+- Configure branded, federated login flows for each organization.
+- Implement role-based access control, such that users can have different roles when authenticating in the context of different organizations.
+- Build administration capabilities into your products, using Organizations APIs, so that those businesses can manage their own organizations.
+
+Note that Organizations is currently only available to customers on our Enterprise and Startup subscription plans.
+
+#### Log in to an organization
+
+Log in to an organization by using `withOrganization()` when configuring the `AuthenticationController`:
+
+```java
+AuthenticationController controller = AuthenticationController.newBuilder("{DOMAIN}", "{CLIENT_ID}", "{CLIENT_SECRET}")
+        .withOrganization("{ORG_ID}")
+        .build();
+```
+
+> When logging into an organization, this library will validate that the `org_id` claim of the ID Token matches the value configured.
+
+#### Accept user invitations
+
+Accept a user invitation by using `withInvitation()` when configuring the `AuthenticationController` (you must also specify the organization):
+
+```java
+AuthenticationController controller = AuthenticationController.newBuilder("{DOMAIN}", "{CLIENT_ID}", "{CLIENT_SECRET}")
+        .withOrganization("{ORG_ID}")
+        .withInvitation("{INVITATION_ID}")
+        .build();
+```
+
+The ID of the invitation and organization are available as query parameters on the invitation URL, e.g., `https://your-domain.auth0.com/login?invitation={INVITATION_ID}&organization={ORG_ID}&organization_name={ORG_NAME}`
+
 ### Troubleshooting
 
 #### Allowing a clock skew

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 group 'com.auth0'
@@ -56,7 +56,7 @@ dependencies {
     implementation 'com.google.guava:guava-annotations:r03'
     implementation 'commons-codec:commons-codec:1.15'
 
-    api 'com.auth0:auth0:1.27.0'
+    api 'com.auth0:auth0:1.28.0'
     api 'com.auth0:java-jwt:3.13.0'
     api 'com.auth0:jwks-rsa:0.15.0'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,9 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        jcenter()
     }
     plugins {
-        id 'com.auth0.gradle.oss-library.java' version '0.14.0'
+        id 'com.auth0.gradle.oss-library.java' version '0.15.1'
         id 'com.jfrog.bintray' version '1.8.5'
     }
 }

--- a/src/main/java/com/auth0/AuthenticationController.java
+++ b/src/main/java/com/auth0/AuthenticationController.java
@@ -58,6 +58,8 @@ public class AuthenticationController {
         private Integer clockSkew;
         private Integer authenticationMaxAge;
         private boolean useLegacySameSiteCookie;
+        private String organization;
+        private String invitation;
 
         Builder(String domain, String clientId, String clientSecret) {
             Validate.notNull(domain);
@@ -135,6 +137,31 @@ public class AuthenticationController {
         }
 
         /**
+         * Sets the organization query string parameter value used to login to an organization.
+         *
+         * @param organization The ID of the organization to log the user in to.
+         * @return the builder instance.
+         */
+        public Builder withOrganization(String organization) {
+            Validate.notNull(organization);
+            this.organization = organization;
+            return this;
+        }
+
+        /**
+         * Sets the invitation query string parameter to join an organization. If using this, you must also specify the
+         * organization using {@linkplain Builder#withOrganization(String)}.
+         *
+         * @param invitation The ID of the invitation to accept. This is available on the URL that is provided when accepting an invitation.
+         * @return the builder instance.
+         */
+        public Builder withInvitation(String invitation) {
+            Validate.notNull(invitation);
+            this.invitation = invitation;
+            return this;
+        }
+
+        /**
          * Create a new {@link AuthenticationController} instance that will handle both Code Grant and Implicit Grant flows using either Code Exchange or Token Signature verification.
          *
          * @return a new instance of {@link AuthenticationController}.
@@ -161,9 +188,12 @@ public class AuthenticationController {
             IdTokenVerifier.Options verifyOptions = createIdTokenVerificationOptions(issuer, clientId, signatureVerifier);
             verifyOptions.setClockSkew(clockSkew);
             verifyOptions.setMaxAge(authenticationMaxAge);
+            verifyOptions.setOrganization(this.organization);
 
             RequestProcessor processor = new RequestProcessor.Builder(apiClient, responseType, verifyOptions)
                     .withLegacySameSiteCookie(useLegacySameSiteCookie)
+                    .withOrganization(organization)
+                    .withInvitation(invitation)
                     .build();
 
             return new AuthenticationController(processor);

--- a/src/main/java/com/auth0/AuthorizeUrl.java
+++ b/src/main/java/com/auth0/AuthorizeUrl.java
@@ -53,6 +53,26 @@ public class AuthorizeUrl {
     }
 
     /**
+     * Sets the organization parameter on the authorize URL
+     * @param organization The organization parameter value
+     * @return this builder instance
+     */
+    public AuthorizeUrl withOrganization(String organization) {
+        builder.withOrganization(organization);
+        return this;
+    }
+
+    /**
+     * Sets the invitation parameter on the authorize URL
+     * @param invitation The invitation parameter value
+     * @return this builder instance
+     */
+    public AuthorizeUrl withInvitation(String invitation) {
+        builder.withInvitation(invitation);
+        return this;
+    }
+
+    /**
      * Sets the connection value.
      *
      * @param connection connection to set

--- a/src/main/java/com/auth0/AuthorizeUrl.java
+++ b/src/main/java/com/auth0/AuthorizeUrl.java
@@ -53,9 +53,10 @@ public class AuthorizeUrl {
     }
 
     /**
-     * Sets the organization parameter on the authorize URL
-     * @param organization The organization parameter value
-     * @return this builder instance
+     * Sets the organization query string parameter value used to login to an organization.
+     *
+     * @param organization The ID of the organization to log the user in to.
+     * @return the builder instance.
      */
     public AuthorizeUrl withOrganization(String organization) {
         builder.withOrganization(organization);
@@ -63,9 +64,11 @@ public class AuthorizeUrl {
     }
 
     /**
-     * Sets the invitation parameter on the authorize URL
-     * @param invitation The invitation parameter value
-     * @return this builder instance
+     * Sets the invitation query string parameter to join an organization. If using this, you must also specify the
+     * organization using {@linkplain AuthorizeUrl#withOrganization(String)}.
+     *
+     * @param invitation The ID of the invitation to accept. This is available on the URL that is provided when accepting an invitation.
+     * @return the builder instance.
      */
     public AuthorizeUrl withInvitation(String invitation) {
         builder.withInvitation(invitation);

--- a/src/main/java/com/auth0/IdTokenVerifier.java
+++ b/src/main/java/com/auth0/IdTokenVerifier.java
@@ -55,6 +55,17 @@ class IdTokenVerifier {
             throw new TokenValidationException(String.format("Audience (aud) claim mismatch in the ID token; expected \"%s\" but found \"%s\"", verifyOptions.audience, decoded.getAudience()));
         }
 
+        // validate org if set
+        if (verifyOptions.organization != null) {
+            String orgIdClaim = decoded.getClaim("org_id").asString();
+            if (isEmpty(orgIdClaim)) {
+                throw new TokenValidationException("Organization Id (org_id) claim must be a string present in the ID token");
+            }
+            if (!verifyOptions.organization.equals(orgIdClaim)) {
+                throw new TokenValidationException(String.format("Organization (org_id) claim mismatch in the ID token; expected \"%s\" but found \"%s\"", verifyOptions.organization, orgIdClaim));
+            }
+        }
+
         final Calendar cal = Calendar.getInstance();
         final Date now = verifyOptions.clock != null ? verifyOptions.clock : cal.getTime();
         final int clockSkew = verifyOptions.clockSkew != null ? verifyOptions.clockSkew : DEFAULT_CLOCK_SKEW;
@@ -127,6 +138,7 @@ class IdTokenVerifier {
         private Integer maxAge;
         Integer clockSkew;
         Date clock;
+        String organization;
 
         public Options(String issuer, String audience, SignatureVerifier verifier) {
             Validate.notNull(issuer);
@@ -155,6 +167,10 @@ class IdTokenVerifier {
 
         Integer getMaxAge() {
             return maxAge;
+        }
+
+        void setOrganization(String organization) {
+            this.organization = organization;
         }
     }
 }

--- a/src/test/java/com/auth0/AuthenticationControllerTest.java
+++ b/src/test/java/com/auth0/AuthenticationControllerTest.java
@@ -505,4 +505,39 @@ public class AuthenticationControllerTest {
         controller.handle(request);
     }
 
+    @Test
+    public void shouldAllowOrganizationParameter() {
+        AuthenticationController controller = AuthenticationController.newBuilder("DOMAIN", "CLIENT_ID", "SECRET")
+                .withOrganization("orgId_abc123")
+                .build();
+
+        String authUrl = controller.buildAuthorizeUrl(new MockHttpServletRequest(), new MockHttpServletResponse(), "https://me.com/redirect")
+                .build();
+        assertThat(authUrl, containsString("organization=orgId_abc123"));
+    }
+
+    @Test
+    public void shouldThrowOnNullOrganizationParameter() {
+        exception.expect(NullPointerException.class);
+        AuthenticationController.newBuilder("DOMAIN", "CLIENT_ID", "SECRET")
+                .withOrganization(null);
+    }
+
+    @Test
+    public void shouldAllowInvitationParameter() {
+        AuthenticationController controller = AuthenticationController.newBuilder("DOMAIN", "CLIENT_ID", "SECRET")
+                .withInvitation("invitation_123")
+                .build();
+
+        String authUrl = controller.buildAuthorizeUrl(new MockHttpServletRequest(), new MockHttpServletResponse(), "https://me.com/redirect")
+                .build();
+        assertThat(authUrl, containsString("invitation=invitation_123"));
+    }
+
+    @Test
+    public void shouldThrowOnNullInvitationParameter() {
+        exception.expect(NullPointerException.class);
+        AuthenticationController.newBuilder("DOMAIN", "CLIENT_ID", "SECRET")
+                .withInvitation(null);
+    }
 }

--- a/src/test/java/com/auth0/IdTokenVerifierTest.java
+++ b/src/test/java/com/auth0/IdTokenVerifierTest.java
@@ -459,6 +459,123 @@ public class IdTokenVerifierTest {
         new IdTokenVerifier().verify(token, opts);
     }
 
+    @Test
+    public void succeedsWhenOrganizationMatchesExpected() {
+        String token = JWT.create()
+                .withSubject("auth0|sdk458fks")
+                .withAudience(AUDIENCE)
+                .withIssuedAt(getYesterday())
+                .withExpiresAt(getTomorrow())
+                .withIssuer("https://" + DOMAIN + "/")
+                .withClaim("org_id", "org_123")
+                .sign(Algorithm.HMAC256("secret"));
+
+        String jwt = JWT.decode(token).getToken();
+
+        IdTokenVerifier.Options opts = configureOptions(jwt);
+        opts.setOrganization("org_123");
+
+        new IdTokenVerifier().verify(token, opts);
+    }
+
+    @Test
+    public void failsWhenOrganizationDoesNotMatchExpected() {
+        exception.expect(TokenValidationException.class);
+        exception.expectMessage("Organization (org_id) claim mismatch in the ID token; expected \"org_abc\" but found \"org_123\"");
+
+        String token = JWT.create()
+                .withSubject("auth0|sdk458fks")
+                .withAudience(AUDIENCE)
+                .withIssuedAt(getYesterday())
+                .withExpiresAt(getTomorrow())
+                .withIssuer("https://" + DOMAIN + "/")
+                .withClaim("org_id", "org_123")
+                .sign(Algorithm.HMAC256("secret"));
+
+        String jwt = JWT.decode(token).getToken();
+
+        IdTokenVerifier.Options opts = configureOptions(jwt);
+        opts.setOrganization("org_abc");
+
+        new IdTokenVerifier().verify(token, opts);
+    }
+
+    @Test
+    public void failsWhenOrganizationExpectedButNotPresent() {
+        exception.expect(TokenValidationException.class);
+        exception.expectMessage("Organization Id (org_id) claim must be a string present in the ID token");
+
+        String token = JWT.create()
+                .withSubject("auth0|sdk458fks")
+                .withAudience(AUDIENCE)
+                .withIssuedAt(getYesterday())
+                .withExpiresAt(getTomorrow())
+                .withIssuer("https://" + DOMAIN + "/")
+                .sign(Algorithm.HMAC256("secret"));
+
+        String jwt = JWT.decode(token).getToken();
+
+        IdTokenVerifier.Options opts = configureOptions(jwt);
+        opts.setOrganization("org_123");
+
+        new IdTokenVerifier().verify(token, opts);
+    }
+
+    @Test
+    public void failsWhenOrganizationExpectedButClaimIsNotString() {
+        exception.expect(TokenValidationException.class);
+        exception.expectMessage("Organization Id (org_id) claim must be a string present in the ID token");
+
+        String token = JWT.create()
+                .withSubject("auth0|sdk458fks")
+                .withAudience(AUDIENCE)
+                .withIssuedAt(getYesterday())
+                .withExpiresAt(getTomorrow())
+                .withIssuer("https://" + DOMAIN + "/")
+                .withClaim("org_id", 42)
+                .sign(Algorithm.HMAC256("secret"));
+
+        String jwt = JWT.decode(token).getToken();
+
+        IdTokenVerifier.Options opts = configureOptions(jwt);
+        opts.setOrganization("org_123");
+
+        new IdTokenVerifier().verify(token, opts);
+    }
+
+    @Test
+    public void succeedsWhenOrganizationNotSpecifiedButIsPresent() {
+        String token = JWT.create()
+                .withSubject("auth0|sdk458fks")
+                .withAudience(AUDIENCE)
+                .withIssuedAt(getYesterday())
+                .withExpiresAt(getTomorrow())
+                .withIssuer("https://" + DOMAIN + "/")
+                .withClaim("org_id", "org_123")
+                .sign(Algorithm.HMAC256("secret"));
+
+        String jwt = JWT.decode(token).getToken();
+
+        IdTokenVerifier.Options opts = configureOptions(jwt);
+        new IdTokenVerifier().verify(token, opts);
+    }
+
+    @Test
+    public void getJWT() {
+        String token = JWT.create()
+                .withSubject("auth0|sdk458fks")
+                .withAudience("tokens-test-123")
+                .withIssuedAt(new Date(Long.parseLong("1587592561") * 1000))
+                .withExpiresAt(new Date(Long.parseLong("1587765361") * 1000))
+                .withIssuer("https://tokens-test.auth0.com/")
+                .withClaim("org_id", 42)
+                .sign(Algorithm.HMAC256("secret"));
+
+        String jwt = JWT.decode(token).getToken();
+        System.out.println(jwt);
+
+    }
+
     private IdTokenVerifier.Options configureOptions(String token) {
         DecodedJWT decodedJWT = JWT.decode(token);
         SignatureVerifier verifier = mock(SignatureVerifier.class);

--- a/src/test/java/com/auth0/IdTokenVerifierTest.java
+++ b/src/test/java/com/auth0/IdTokenVerifierTest.java
@@ -560,22 +560,6 @@ public class IdTokenVerifierTest {
         new IdTokenVerifier().verify(token, opts);
     }
 
-    @Test
-    public void getJWT() {
-        String token = JWT.create()
-                .withSubject("auth0|sdk458fks")
-                .withAudience("tokens-test-123")
-                .withIssuedAt(new Date(Long.parseLong("1587592561") * 1000))
-                .withExpiresAt(new Date(Long.parseLong("1587765361") * 1000))
-                .withIssuer("https://tokens-test.auth0.com/")
-                .withClaim("org_id", 42)
-                .sign(Algorithm.HMAC256("secret"));
-
-        String jwt = JWT.decode(token).getToken();
-        System.out.println(jwt);
-
-    }
-
     private IdTokenVerifier.Options configureOptions(String token) {
         DecodedJWT decodedJWT = JWT.decode(token);
         SignatureVerifier verifier = mock(SignatureVerifier.class);


### PR DESCRIPTION
### Changes

This PR adds support for logging into an organization, as well as accepting an invitation to an organization during the invitation login flow.

- Updates `auth0-java` dependency to `1.28.0` to use the Organization features added in that release
- Adds the ability to specify an `organization` and `invitation` when configuring the `AuthtenticationController`
- Updates the `IdTokenVerifier` to verify the `org_id` claim, if the `organization` is specified on the `AuthenticationController`
- Adds documentation to the `README` for using the organizations feature

### References

- https://github.com/auth0/auth0-java/pull/338

### Testing

In addition to adding unit tests, I created a simple webapp using this change to verify that a user is able to log into an organization, as well as accept an invitation.

- [X] This change adds test coverage
- [ ] This change has been tested on the latest version of Java or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
