### PR TITLE
[SDK-2565] Enable network client configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,9 +56,9 @@ dependencies {
     implementation 'com.google.guava:guava-annotations:r03'
     implementation 'commons-codec:commons-codec:1.15'
 
-    api 'com.auth0:auth0:1.28.0'
-    api 'com.auth0:java-jwt:3.13.0'
-    api 'com.auth0:jwks-rsa:0.15.0'
+    api 'com.auth0:auth0:1.31.0'
+    api 'com.auth0:java-jwt:3.16.0'
+    api 'com.auth0:jwks-rsa:0.18.0'
 
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.64'
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'


### PR DESCRIPTION
This library uses the `AuthAPI` client from `auth0-java` to perform authentication requests using the Auth0 Authentication API. The `AuthAPI` client supports the customization of the networking client through the `HttpOptions` configuration class. This change enables the `AuthenticationController` to be configured with a `HttpOptions` object, which if specified will be used to configure the `AuthAPI` client.