### PR TITLE
Update OSS release plugin version

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="CompilerConfiguration">
     <bytecodeTargetLevel>
-      <module name="mvc-auth-commons_main" target="1.7" />
+      <module name="mvc-auth-commons_main" target="1.8" />
       <module name="mvc-auth-commons_test" target="1.8" />
     </bytecodeTargetLevel>
   </component>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -3,7 +3,7 @@
   <component name="CompilerConfiguration">
     <bytecodeTargetLevel>
       <module name="mvc-auth-commons_main" target="1.8" />
-      <module name="mvc-auth-commons_test" target="1.8" />
+      <module name="mvc-auth-commons_test" target="8" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'java'
     id 'jacoco'
     id 'com.auth0.gradle.oss-library.java'
-    id 'com.jfrog.bintray'
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,12 @@ jacocoTestReport {
     }
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
+
 compileJava {
     sourceCompatibility '1.8'
     targetCompatibility '1.8'

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,7 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id 'com.auth0.gradle.oss-library.java' version '0.15.1'
+        id 'com.auth0.gradle.oss-library.java' version '0.16.0'
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,6 @@ pluginManagement {
     }
     plugins {
         id 'com.auth0.gradle.oss-library.java' version '0.15.1'
-        id 'com.jfrog.bintray' version '1.8.5'
     }
 }
 


### PR DESCRIPTION
### Changes
This PR updates the OSS release plugin version to 0.16.0, which makes use of a newer Javadoc HTML template.

I also removed the bintray plugin which is no longer used.