### PR TITLE
Fix error 'You sent http://..., and we expected https://..' 

### DIFF
--- a/src/main/java/com/auth0/RequestProcessor.java
+++ b/src/main/java/com/auth0/RequestProcessor.java
@@ -3,13 +3,15 @@ package com.auth0;
 import com.auth0.client.auth.AuthAPI;
 import com.auth0.exception.Auth0Exception;
 import com.auth0.json.auth.TokenHolder;
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.Validate;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.auth0.InvalidRequestException.*;
 
@@ -191,6 +193,24 @@ class RequestProcessor {
     }
 
     /**
+     * Manage the case when we are behind a reverse proxy which manage SSL.
+     * reverse proxy should send X-Forwarded-Protocol header with https for value
+     * @param request the HTTP request
+     * @return a string redirectUri
+     */
+    String buildRedirectUri(HttpServletRequest request) {
+        String redirectUri = request.getRequestURL().toString();
+        Map<String, String> headers = Collections.list(request.getHeaderNames())
+                .stream()
+                .collect(Collectors.toMap(h -> h, request::getHeader));
+        final String protocol = headers.get("X-Forwarded-Proto");
+        if(protocol!=null && protocol.equalsIgnoreCase("https")) {
+            redirectUri = redirectUri.replace("http://", "https://");
+        }
+        return redirectUri;
+    }
+
+    /**
      * Obtains code request tokens (if using Code flow) and validates the ID token.
      * @param request the HTTP request
      * @param frontChannelTokens the tokens obtained from the front channel
@@ -211,7 +231,7 @@ class RequestProcessor {
             }
             if (responseTypeList.contains(KEY_CODE)) {
                 // Code/Hybrid flow
-                String redirectUri = request.getRequestURL().toString();
+                String redirectUri = buildRedirectUri(request);
                 codeExchangeTokens = exchangeCodeForTokens(authorizationCode, redirectUri);
                 if (!responseTypeList.contains(KEY_ID_TOKEN)) {
                     // If we already verified the front-channel token, don't verify it again.


### PR DESCRIPTION
= Use the standard X-Forwarded-Proto behind reverse proxy if it present.

### Changes

Hi! 
My company has the need to use Auth0 SDK behind nginx.
But this SDK can't be used behind a reverse proxy which manage the SSL termination.
It's not convenient to manage SSL directly on the backend.
Without that, we fall always into the error 'You sent http://..., and we expected https://..'  during the validation of token.
I've made a little change in the RequestProcessor class, more precisely in the getVerifiedTokens method.
I added a method to take into account the header X-Forwarded-Proto if it exists.
I am not a java expert, this code can be greatly improved.
Regards

### References

Please include relevant links supporting this change such as a:

- community post:
- https://community.auth0.com/t/http-https-protocols-behind-load-balancer/8834
- https://community.auth0.com/t/error-on-redirect-urls/55009
- https://community.auth0.com/t/http-https-protocols-issue/11940

### Testing

- [x ] This change adds test coverage

### Checklist

- [x ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ x] All existing and new tests complete without errors
