### PR TITLE
Fix error 'You sent http://..., and we expected https://..'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.8.0](https://github.com/auth0/auth0-java-mvc-common/tree/1.8.0) (2021-07-06)
+[Full Changelog](https://github.com/auth0/auth0-java-mvc-common/compare/1.7.0...1.8.0)
+
+**Changed**
+- Update Auth0 libraries to latest [\#89](https://github.com/auth0/auth0-java-mvc-common/pull/89) ([lbalmaceda](https://github.com/lbalmaceda))
+- Update OSS release plugin version [\#88](https://github.com/auth0/auth0-java-mvc-common/pull/88) ([lbalmaceda](https://github.com/lbalmaceda))
+
 ## [1.7.0](https://github.com/auth0/auth0-java-mvc-common/tree/1.7.0) (2021-05-27)
 [Full Changelog](https://github.com/auth0/auth0-java-mvc-common/compare/1.6.0...1.7.0)
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Via Maven:
 <dependency>
     <groupId>com.auth0</groupId>
     <artifactId>mvc-auth-commons</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
 </dependency>
 ```
 
 or Gradle:
 
 ```gradle
-implementation 'com.auth0:mvc-auth-commons:1.7.0'
+implementation 'com.auth0:mvc-auth-commons:1.8.0'
 ```
 
 

--- a/src/main/java/com/auth0/RequestProcessor.java
+++ b/src/main/java/com/auth0/RequestProcessor.java
@@ -10,6 +10,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.auth0.InvalidRequestException.*;
 
@@ -191,6 +194,24 @@ class RequestProcessor {
     }
 
     /**
+     * Manage the case when we are behind a reverse proxy which manage SSL.
+     * reverse proxy should send X-Forwarded-Protocol header with https for value
+     * @param request the HTTP request
+     * @return a string redirectUri
+     */
+    String buildRedirectUri(HttpServletRequest request) {
+        String redirectUri = request.getRequestURL().toString();
+        Map<String, String> headers = Collections.list(request.getHeaderNames())
+                .stream()
+                .collect(Collectors.toMap(h -> h, request::getHeader));
+        final String protocol = headers.get("X-Forwarded-Proto");
+        if(protocol!=null && protocol.equals("https")) {
+            redirectUri = redirectUri.replace("http://", "https://");
+        }
+        return redirectUri;
+    }
+
+    /**
      * Obtains code request tokens (if using Code flow) and validates the ID token.
      * @param request the HTTP request
      * @param frontChannelTokens the tokens obtained from the front channel
@@ -211,7 +232,7 @@ class RequestProcessor {
             }
             if (responseTypeList.contains(KEY_CODE)) {
                 // Code/Hybrid flow
-                String redirectUri = request.getRequestURL().toString();
+                String redirectUri = buildRedirectUri(request);
                 codeExchangeTokens = exchangeCodeForTokens(authorizationCode, redirectUri);
                 if (!responseTypeList.contains(KEY_ID_TOKEN)) {
                     // If we already verified the front-channel token, don't verify it again.


### PR DESCRIPTION
Fix error 'You sent http://..., and we expected https://..'
= Use the standard X-Forwarded-Proto behind reverse proxy if it present

### Changes

Hello!
My company has the need to use Auth0 SDK behind nginx.
But this SDK can't be used behind a reverse proxy which manage the SSL termination.
It's not convenient to manage SSL directly on the backend.
Without that, we fall always into the error 'You sent http://..., and we expected https://..' during the validation of token.
I've made a little change in the RequestProcessor class, more precisely in the getVerifiedTokens method.
I added a method to take into account the header X-Forwarded-Proto if it exists.
Regards

### References

support ticket
https://community.auth0.com/t/http-https-protocols-behind-load-balancer/8834
https://community.auth0.com/t/error-on-redirect-urls/55009
https://community.auth0.com/t/http-https-protocols-issue/11940

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x ] This change adds test coverage
- [x] This change has been tested on the latest version of Java or why not

### Checklist

- [ x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x ] All existing and new tests complete without errors
