### PR TITLE
Fix error 'You sent http://..., and we expected https://..'

### DIFF
--- a/src/test/java/com/auth0/RequestProcessorTest.java
+++ b/src/test/java/com/auth0/RequestProcessorTest.java
@@ -447,6 +447,41 @@ public class RequestProcessorTest {
     }
 
     @Test
+    public void shouldBuildRedirectUrlCorrectlyBehindReverseProxy() {
+        AuthAPI client = new AuthAPI("me.auth0.com", "clientId", "clientSecret");
+        SignatureVerifier signatureVerifier = mock(SignatureVerifier.class);
+        IdTokenVerifier.Options verifyOptions = new IdTokenVerifier.Options("issuer", "audience", signatureVerifier);
+        RequestProcessor handler = new RequestProcessor.Builder(client, "code", verifyOptions)
+                .build();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        request.setScheme("http");
+        request.setServerName("me.auth0.com");
+        request.addHeader("multi-value-header", "one,two,three");
+        request.addHeader("empty-header", "");
+
+        String redirectUrl = handler.buildRedirectUri(request);
+        assertThat(redirectUrl, is(notNullValue()));
+        assertThat(redirectUrl, CoreMatchers.equalTo("http://me.auth0.com"));
+
+        request.addHeader("X-Forwarded-Proto", "HTTPS");
+        redirectUrl = handler.buildRedirectUri(request);
+        assertThat(redirectUrl, is(notNullValue()));
+        assertThat(redirectUrl, CoreMatchers.equalTo("http://me.auth0.com"));
+
+        request = new MockHttpServletRequest();
+        request.setScheme("http");
+        request.setServerName("me.auth0.com");
+        request.addHeader("multi-value-header", "one,two,three");
+        request.addHeader("empty-header", "");
+        request.addHeader("X-Forwarded-Proto", "https");
+        redirectUrl = handler.buildRedirectUri(request);
+
+        assertThat(redirectUrl, is(notNullValue()));
+        assertThat(redirectUrl, CoreMatchers.equalTo("https://me.auth0.com"));
+    }
+
+    @Test
     public void shouldSetMaxAgeIfProvided() {
         AuthAPI client = new AuthAPI("me.auth0.com", "clientId", "clientSecret");
         when(verifyOptions.getMaxAge()).thenReturn(906030);


### PR DESCRIPTION
### Changes

Hello!
My company has the need to use Auth0 SDK behind nginx.
But this SDK can't be used behind a reverse proxy which manage the SSL termination.
It's not convenient to manage SSL directly on the backend.
Without that, we fall always into the error 'You sent http://..., and we expected https://..' during the validation of token.
I've made a little change in the RequestProcessor class, more precisely in the getVerifiedTokens method.
I added a method to take into account the header X-Forwarded-Proto if it exists.
Regards

### References

support ticket
https://community.auth0.com/t/http-https-protocols-behind-load-balancer/8834
https://community.auth0.com/t/error-on-redirect-urls/55009
https://community.auth0.com/t/http-https-protocols-issue/11940

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of Java or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
