### PR TITLE
Migrate tests to the modern JUnit Jupiter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ compileJava {
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         events "skipped", "failed"
         exceptionFormat "short"
@@ -69,7 +70,7 @@ dependencies {
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'
     testImplementation 'org.hamcrest:hamcrest-core:1.3'
     testImplementation 'org.mockito:mockito-core:2.8.9'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
     testImplementation 'org.springframework:spring-test:4.3.14.RELEASE'
     testImplementation 'com.squareup.okhttp3:okhttp:4.9.0'
 }

--- a/src/test/java/com/auth0/AuthenticationControllerTest.java
+++ b/src/test/java/com/auth0/AuthenticationControllerTest.java
@@ -7,10 +7,8 @@ import com.auth0.json.auth.TokenHolder;
 import com.auth0.jwk.JwkProvider;
 import com.auth0.net.Telemetry;
 import com.auth0.net.TokenRequest;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -25,13 +23,12 @@ import java.util.List;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @SuppressWarnings("deprecated")
 public class AuthenticationControllerTest {
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
     @Mock
     private AuthAPI client;
     @Mock
@@ -41,7 +38,7 @@ public class AuthenticationControllerTest {
 
     private AuthenticationController.Builder builderSpy;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
@@ -252,39 +249,34 @@ public class AuthenticationControllerTest {
 
     @Test
     public void shouldThrowOnMissingDomain() {
-        exception.expect(NullPointerException.class);
-
-        AuthenticationController.newBuilder(null, "clientId", "clientSecret");
+        assertThrows(NullPointerException.class,
+                () -> AuthenticationController.newBuilder(null, "clientId", "clientSecret"));
     }
 
     @Test
     public void shouldThrowOnMissingClientId() {
-        exception.expect(NullPointerException.class);
-
-        AuthenticationController.newBuilder("domain", null, "clientSecret");
+        assertThrows(NullPointerException.class,
+                () -> AuthenticationController.newBuilder("domain", null, "clientSecret"));
     }
 
     @Test
     public void shouldThrowOnMissingClientSecret() {
-        exception.expect(NullPointerException.class);
-
-        AuthenticationController.newBuilder("domain", "clientId", null);
+        assertThrows(NullPointerException.class,
+                () -> AuthenticationController.newBuilder("domain", "clientId", null));
     }
 
     @Test
     public void shouldThrowOnMissingJwkProvider() {
-        exception.expect(NullPointerException.class);
-
-        AuthenticationController.newBuilder("domain", "clientId", "clientSecret")
-                .withJwkProvider(null);
+        assertThrows(NullPointerException.class,
+                () -> AuthenticationController.newBuilder("domain", "clientId", "clientSecret")
+                        .withJwkProvider(null));
     }
 
     @Test
     public void shouldThrowOnMissingResponseType() {
-        exception.expect(NullPointerException.class);
-
-        AuthenticationController.newBuilder("domain", "clientId", "clientSecret")
-                .withResponseType(null);
+        assertThrows(NullPointerException.class,
+                () -> AuthenticationController.newBuilder("domain", "clientId", "clientSecret")
+                        .withResponseType(null));
     }
 
     @Test
@@ -551,9 +543,9 @@ public class AuthenticationControllerTest {
 
     @Test
     public void shouldThrowOnNullOrganizationParameter() {
-        exception.expect(NullPointerException.class);
-        AuthenticationController.newBuilder("DOMAIN", "CLIENT_ID", "SECRET")
-                .withOrganization(null);
+        assertThrows(NullPointerException.class,
+                () -> AuthenticationController.newBuilder("DOMAIN", "CLIENT_ID", "SECRET")
+                        .withOrganization(null));
     }
 
     @Test
@@ -569,8 +561,8 @@ public class AuthenticationControllerTest {
 
     @Test
     public void shouldThrowOnNullInvitationParameter() {
-        exception.expect(NullPointerException.class);
-        AuthenticationController.newBuilder("DOMAIN", "CLIENT_ID", "SECRET")
-                .withInvitation(null);
+        assertThrows(NullPointerException.class,
+                () -> AuthenticationController.newBuilder("DOMAIN", "CLIENT_ID", "SECRET")
+                        .withInvitation(null));
     }
 }

--- a/src/test/java/com/auth0/AuthorizeUrlTest.java
+++ b/src/test/java/com/auth0/AuthorizeUrlTest.java
@@ -2,10 +2,8 @@ package com.auth0;
 
 import com.auth0.client.auth.AuthAPI;
 import okhttp3.HttpUrl;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -14,17 +12,17 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.Collection;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AuthorizeUrlTest {
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
     private AuthAPI client;
     private HttpServletResponse response;
     private HttpServletRequest request;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         client = new AuthAPI("domain.auth0.com", "clientId", "clientSecret");
         request = new MockHttpServletRequest();
@@ -195,48 +193,46 @@ public class AuthorizeUrlTest {
 
     @Test
     public void shouldThrowWhenReusingTheInstance() {
-        exception.expect(IllegalStateException.class);
-        exception.expectMessage("The AuthorizeUrl instance must not be reused.");
-
         AuthorizeUrl builder = new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token");
         String firstCall = builder.build();
         assertThat(firstCall, is(notNullValue()));
-        builder.build();
+        IllegalStateException e = assertThrows(IllegalStateException.class, builder::build);
+        assertEquals("The AuthorizeUrl instance must not be reused.", e.getMessage());
     }
 
     @Test
     public void shouldThrowWhenChangingTheRedirectURI() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Redirect URI cannot be changed once set.");
-
-        new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
-                .withParameter("redirect_uri", "new_value");
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class,
+                () -> new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
+                        .withParameter("redirect_uri", "new_value"));
+        assertEquals("Redirect URI cannot be changed once set.", e.getMessage());
     }
 
     @Test
     public void shouldThrowWhenChangingTheResponseType() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Response type cannot be changed once set.");
-
-        new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
-                .withParameter("response_type", "new_value");
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class,
+                () -> new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
+                        .withParameter("response_type", "new_value"));
+        assertEquals("Response type cannot be changed once set.", e.getMessage());
     }
 
     @Test
     public void shouldThrowWhenChangingTheStateUsingCustomParameterSetter() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Please, use the dedicated methods for setting the 'nonce' and 'state' parameters.");
-
-        new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
-                .withParameter("state", "new_value");
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class,
+                () -> new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
+                        .withParameter("state", "new_value"));
+        assertEquals("Please, use the dedicated methods for setting the 'nonce' and 'state' parameters.", e.getMessage());
     }
 
     @Test
     public void shouldThrowWhenChangingTheNonceUsingCustomParameterSetter() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Please, use the dedicated methods for setting the 'nonce' and 'state' parameters.");
-
-        new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
-                .withParameter("nonce", "new_value");
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class,
+                () -> new AuthorizeUrl(client, request, response, "https://redirect.to/me", "id_token token")
+                        .withParameter("nonce", "new_value"));
+        assertEquals("Please, use the dedicated methods for setting the 'nonce' and 'state' parameters.", e.getMessage());
     }
 }

--- a/src/test/java/com/auth0/IdTokenVerifierTest.java
+++ b/src/test/java/com/auth0/IdTokenVerifierTest.java
@@ -3,14 +3,14 @@ package com.auth0;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Calendar;
 import java.util.Date;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -23,59 +23,50 @@ public class IdTokenVerifierTest {
     private final static Date DEFAULT_CLOCK = new Date(1567400400000L);
     private final static Integer DEFAULT_CLOCK_SKEW = 60;
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     private SignatureVerifier signatureVerifier;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         signatureVerifier = mock(SignatureVerifier.class);
     }
 
     @Test
     public void failsToCreateOptionsWhenIssuerIsNull() {
-        exception.expect(NullPointerException.class);
-        new IdTokenVerifier.Options(null, "audience", signatureVerifier);
+        assertThrows(NullPointerException.class,
+                () -> new IdTokenVerifier.Options(null, "audience", signatureVerifier));
     }
 
     @Test
     public void failsToCreateOptionsWhenAudienceIsNull() {
-        exception.expect(NullPointerException.class);
-        new IdTokenVerifier.Options("issuer", null, signatureVerifier);
+        assertThrows(NullPointerException.class,
+                () -> new IdTokenVerifier.Options("issuer", null, signatureVerifier));
     }
 
     @Test
     public void failsToCreateOptionsWhenVerifierIsNull() {
-        exception.expect(NullPointerException.class);
-        new IdTokenVerifier.Options("issuer", "audience", null);
+        assertThrows(NullPointerException.class,
+                () -> new IdTokenVerifier.Options("issuer", "audience", null));
     }
 
     @Test
     public void failsWhenIDTokenMissing() {
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("ID token is required but missing");
-
         IdTokenVerifier.Options opts = new IdTokenVerifier.Options("issuer", "audience", signatureVerifier);
         IdTokenVerifier verifier = new IdTokenVerifier();
-        verifier.verify(null, opts);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> verifier.verify(null, opts));
+        assertEquals("ID token is required but missing", e.getMessage());
     }
 
     @Test
     public void failsWhenIDTokenEmpty() {
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("ID token is required but missing");
-
         IdTokenVerifier.Options opts = new IdTokenVerifier.Options("issuer", "audience", signatureVerifier);
         IdTokenVerifier verifier = new IdTokenVerifier();
-        verifier.verify("", opts);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> verifier.verify("", opts));
+        assertEquals("ID token is required but missing", e.getMessage());
     }
 
     @Test
     public void failsWhenOptionsIsNull() {
-        exception.expect(NullPointerException.class);
-
-        new IdTokenVerifier().verify("token", null);
+        assertThrows(NullPointerException.class, () -> new IdTokenVerifier().verify("token", null));
     }
 
     @Test
@@ -85,10 +76,8 @@ public class IdTokenVerifierTest {
         SignatureVerifier signatureVerifier = new SymmetricSignatureVerifier("secret");
         IdTokenVerifier.Options opts = new IdTokenVerifier.Options(DOMAIN, AUDIENCE, signatureVerifier);
 
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("ID token could not be decoded");
-
-        new IdTokenVerifier().verify(token, opts);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, opts));
+        assertEquals("ID token could not be decoded", e.getMessage());
     }
 
     @Test
@@ -98,10 +87,8 @@ public class IdTokenVerifierTest {
         SignatureVerifier verifier = new SymmetricSignatureVerifier("asdlk59ckvkr");
         IdTokenVerifier.Options opts = new IdTokenVerifier.Options(DOMAIN, AUDIENCE, verifier);
 
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("Invalid token signature");
-
-        new IdTokenVerifier().verify(token, opts);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, opts));
+        assertEquals("Invalid token signature", e.getMessage());
     }
 
     @Test
@@ -109,10 +96,8 @@ public class IdTokenVerifierTest {
         String token = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC0xMjMiXSwiZXhwIjoxNTY3NDg2ODAwLCJpYXQiOjE1NjczMTQwMDAsIm5vbmNlIjoiYTU5dms1OTIiLCJhenAiOiJ0b2tlbnMtdGVzdC0xMjMiLCJhdXRoX3RpbWUiOjE1NjczMTQwMDB9.B4PGlucyy-fJ4v5NNK2hntvjAf5m8dJf84WttwVnzV0ZlfPbYUSJm7Vc1ys7iMqXAQzAl2I8bDf2qhtLjaLpDKAH9JUvowUpCL7Bgjd7AEc1Te_IUwwxlpCupgseOEL2nrY8enP6On7BO7BBpngmVwnD1DvuA4lNoaaFyWUopha5Dxd5jw64wMqP4lz13C6Kqs8mINZkkw-NgE8DvWszaXeyPaowy-QpfXmPBnw75YLZlGcjr-WQsWQV7rUezq4Tl_11uPivR-fNcEWdG1mAtsnQnB_zJJKaHYlE0g4fey_6H9FKmCvcNkpBGo9ylbitb7jIuExbFEvEd2r_4wKl0g";
         IdTokenVerifier.Options options = configureOptions(token);
 
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("Issuer (iss) claim must be a string present in the ID token");
-
-        new IdTokenVerifier().verify(token, options);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, options));
+        assertEquals("Issuer (iss) claim must be a string present in the ID token", e.getMessage());
     }
 
     @Test
@@ -120,11 +105,10 @@ public class IdTokenVerifierTest {
         String token = "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJzb21ldGhpbmctZWxzZSIsInN1YiI6ImF1dGgwfDEyMzQ1Njc4OSIsImF1ZCI6WyJ0b2tlbnMtdGVzdC0xMjMiLCJleHRlcm5hbC10ZXN0LTEyMyJdLCJleHAiOjE1Njc0ODY4MDAsImlhdCI6MTU2NzMxNDAwMCwibm9uY2UiOiJhNTl2azU5MiIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU2NzMxNDAwMH0.lHFHyg1ei3hK2vB7X1xB9nqksAEnxtv2KKpE_Gih6RezTruF9uZu1PAZTEwxhfj2UrQxwLqCb-t6wyVnxVpCsymSCq9JIiCVgg_cYV38siMs38N9y26BrVeyifj_VOP9Om_vI_hHjOzhi8WmysK2KKAQnn0skKAkq8epY4axCX3NkRaEIMhhTaITYia3GbJ5Qki8WDD9UVucUVOhgSZBV5p1dL39FKgc9k1MOVZJG-zAd_r5GsUIRk-xUwNX0WYwCR9sC2G-FjJTvlFph_4vksponoUWJ-LPTLM0RwGgmEUPhhnIG23UjsNwpnElY4gWfIL0hsO98-5DpGjn8Ejr0w";
         IdTokenVerifier.Options options = configureOptions(token);
 
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage(String.format("Issuer (iss) claim mismatch in the ID token, expected \"%s\", found \"%s\"",
-                "https://" + DOMAIN + "/", "something-else"));
-
-        new IdTokenVerifier().verify(token, options);
+        String errorMessage = String.format("Issuer (iss) claim mismatch in the ID token, expected \"%s\", found \"%s\"",
+                "https://" + DOMAIN + "/", "something-else");
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, options));
+        assertEquals(errorMessage, e.getMessage());
     }
 
     @Test
@@ -132,10 +116,8 @@ public class IdTokenVerifierTest {
         String token = "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC0xMjMiXSwiZXhwIjoxNTY3NDg2ODAwLCJpYXQiOjE1NjczMTQwMDAsIm5vbmNlIjoiYTU5dms1OTIiLCJhenAiOiJ0b2tlbnMtdGVzdC0xMjMiLCJhdXRoX3RpbWUiOjE1NjczMTQwMDB9.fDR9NSbbt75w9nzhL-eBfGjOp16HP2vfnO6m_Oav0xrmmgyYsBZSLOPd2C0O46bp6_2hKjeOUhnwYwjocsdXI4hvfQkyACERtneCkwHwSZPZK-1h6vgGF7b_7ILUywEcgo7F6e1qgFTM93Prqk63cCP53KgOBPyx02y0rqkhUOApCWRVBFrfP92tXvFN7E2phmpf9G68PPjwnEvvQtYOGjvFkaWSja7MKT98f7OxgbenBI_mAZy9LmOqUl3SKJOBe5Fibs1snI0l4nzrgQ1GNxVwyfHOdyq-srdGe8rlFx5kdhWh313EOzWxxGTg4RhGY7Tiz1QWago0VQ5yOt0w8A";
         IdTokenVerifier.Options options = configureOptions(token);
 
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("Subject (sub) claim must be a string present in the ID token");
-
-        new IdTokenVerifier().verify(token, options);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, options));
+        assertEquals("Subject (sub) claim must be a string present in the ID token", e.getMessage());
     }
 
     @Test
@@ -143,10 +125,8 @@ public class IdTokenVerifierTest {
         String token = "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJleHAiOjE1Njc0ODY4MDAsImlhdCI6MTU2NzMxNDAwMCwibm9uY2UiOiJhNTl2azU5MiIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU2NzMxNDAwMH0.XM-IM9CIZ2cJpZZaKooMSmNgvwHPTse6kcIOPATgewRZxrDdCEjtPHmzmSuyDGy84vSR__DJS_kM2jWWwbkjB_PahXes210dpUqitRW3is9xV0-k0LkVwxmhHCM-e9sClbTbcs4zLv6WWFRq4UEU5DU6HhuHLQeeH0eO2Nv_tkvu-JdpmoepHPjW3ecMs0lhzXRT6_2o-ErTPdYt4W6yqpBG57HRIMzs9F72AWcPC6vhLY0IhMqXaq68Ma3jnEPIXUmv52bll0PuQVBqKd-eDH_jD0ZHFUCkwbfWPrkhJz5Q5qLzSzUjnrWKA3KgP4_Z1KfHY2-nQA2ynMgNFSn_eA";
         IdTokenVerifier.Options options = configureOptions(token);
 
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("Audience (aud) claim must be a string or array of strings present in the ID token");
-
-        new IdTokenVerifier().verify(token, options);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, options));
+        assertEquals("Audience (aud) claim must be a string or array of strings present in the ID token", e.getMessage());
     }
 
     @Test
@@ -154,10 +134,8 @@ public class IdTokenVerifierTest {
         String token = "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOiJleHRlcm5hbC10ZXN0LTEyMyIsImV4cCI6MTU2NzQ4NjgwMCwiaWF0IjoxNTY3MzE0MDAwLCJub25jZSI6ImE1OXZrNTkyIiwiYXpwIjoidG9rZW5zLXRlc3QtMTIzIiwiYXV0aF90aW1lIjoxNTY3MzE0MDAwfQ.SxeNIhm8reywgtSSkZ6jCpbZ8KyC09couFjpcrJFktAYKmJZnGQkv0gQLNUuGejORvysznOlhfO2nkF10yT6pKBiye9xZ8TstWQBorDKHL-74n6ZAxjPg1F0vHNokZq0zpPkwV-gKIFY6aPw3vyZTxzR6CMyoJdwc19A0RXPzPt6T7csQeqX0lzGEqqeIbU4VI5XM5RG1VvN82CgTlOQXlFZrKhyJx_xwslyWWDzx7tpPNid1wusvfznTGxoWO2wUBCyW6EhmyHp2euFi1gdJqHQVbrydutPtQ-FGQEwyWACNN8kBWqQ7UEbqimg6C0NTGrRkkKkJ79DmiW7aULHZQ";
         IdTokenVerifier.Options options = configureOptions(token);
 
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage(String.format("Audience (aud) claim mismatch in the ID token; expected \"%s\" but found \"%s\"", AUDIENCE, "[external-test-123]"));
-
-        new IdTokenVerifier().verify(token, options);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, options));
+        assertEquals(String.format("Audience (aud) claim mismatch in the ID token; expected \"%s\" but found \"%s\"", AUDIENCE, "[external-test-123]"), e.getMessage());
     }
 
     @Test
@@ -165,10 +143,8 @@ public class IdTokenVerifierTest {
         String token = "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC0xMjMiXSwiaWF0IjoxNTY3MzE0MDAwLCJub25jZSI6ImE1OXZrNTkyIiwiYXpwIjoidG9rZW5zLXRlc3QtMTIzIiwiYXV0aF90aW1lIjoxNTY3MzE0MDAwfQ.b6saYAZCnCSzpVO0nrAUKVSC1n3GoqUfwrjOXG5gVxda0oFohpYJe68QwzsTmS4fOm7JtbN1FqjVRN6S4i-BnH-XGnciGOMFF4EfaOzsgo7DCrrLrjfx6rmqW8UPYalbfJTQL8mXYnLOxzMGP3DEXNlk-41GSZoFujwTAIqYjrV_Y3MUGYmzcVxdL_h2psLm_p07knMLCm7Cuo8znzKrU4PtuaLflvzorg57S4BD79oLv4uv0_dmhwPUgJDvqWeicR5Qry4aX2L5BT6V-nBWAcu3qVZDymSKcjtTebxszxY1siyA7BQe88ZmgP1bW1KXtMk_fOGsgWHFdu_AH77yow";
         IdTokenVerifier.Options options = configureOptions(token);
 
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("Expiration Time (exp) claim must be a number present in the ID token");
-
-        new IdTokenVerifier().verify(token, options);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, options));
+        assertEquals("Expiration Time (exp) claim must be a number present in the ID token", e.getMessage());
     }
 
     @Test
@@ -184,11 +160,10 @@ public class IdTokenVerifierTest {
         IdTokenVerifier.Options options = configureOptions(token);
         options.setClock(clock);
 
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage(String.format("Expiration Time (exp) claim error in the ID token; current time (%d) is after expiration time (%d)",
-                clock.getTime() / 1000, actualExpTime + DEFAULT_CLOCK_SKEW));
-
-        new IdTokenVerifier().verify(token, options);
+        String errorMessage = String.format("Expiration Time (exp) claim error in the ID token; current time (%d) is after expiration time (%d)",
+                clock.getTime() / 1000, actualExpTime + DEFAULT_CLOCK_SKEW);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, options));
+        assertEquals(errorMessage, e.getMessage());
     }
 
     @Test
@@ -220,10 +195,10 @@ public class IdTokenVerifierTest {
         options.setClockSkew(leeway);
         options.setClock(clock);
 
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage(String.format("Expiration Time (exp) claim error in the ID token; current time (%d) is after expiration time (%d)",
-                clock.getTime() / 1000, ((actualExp.getTime() / 1000) + leeway)));
-        new IdTokenVerifier().verify(token, options);
+        String errorMessage = String.format("Expiration Time (exp) claim error in the ID token; current time (%d) is after expiration time (%d)",
+                clock.getTime() / 1000, ((actualExp.getTime() / 1000) + leeway));
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, options));
+        assertEquals(errorMessage, e.getMessage());
     }
 
     @Test
@@ -243,13 +218,11 @@ public class IdTokenVerifierTest {
 
     @Test
     public void failsWhenIatClaimMissing() {
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("Issued At (iat) claim must be a number present in the ID token");
-
         String token = "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC0xMjMiXSwiZXhwIjoxNTY3NDg2ODAwLCJub25jZSI6ImE1OXZrNTkyIiwiYXpwIjoidG9rZW5zLXRlc3QtMTIzIiwiYXV0aF90aW1lIjoxNTY3MzE0MDAwfQ.SJDgK8W9Y8stMtE9LG2OzHzXzbIDCXg8lRhKyOim4rRXbkg3k0on7gCzN-sy2d5z5TQ-lQzbY3V4z-so3ltVDUYd_8RjmUiKgNK_95UsxfTDM2BlBEQ6USMVl3ojC5jcTBhg5MF16ZBEn94IjIGC9Uks9GPseM-JrtUPx4Uj5VvsBtmeKxLc3rSGt7rYC4JU65Oa-O5pFYRSCbNzRFNHRlmnb5b2uPHxoVLjrJAT0FhlXcsNgfz65MlbXBgAyz7xjCEhw_tTpvptaCwPTeG0mgBYlGQ7Sl3xHJzgG4jLbA7Pvvfcx0MpBPHUZxADh1FFQnf2nHB0ppddiDfOq2mHNA";
 
         IdTokenVerifier.Options options = configureOptions(token);
-        new IdTokenVerifier().verify(token, options);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, options));
+        assertEquals("Issued At (iat) claim must be a number present in the ID token", e.getMessage());
     }
 
     @Test
@@ -258,10 +231,8 @@ public class IdTokenVerifierTest {
         IdTokenVerifier.Options options = configureOptions(token);
         options.setNonce("kssllk59akth");
 
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("Nonce (nonce) claim must be a string present in the ID token");
-
-        new IdTokenVerifier().verify(token, options);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, options));
+        assertEquals("Nonce (nonce) claim must be a string present in the ID token", e.getMessage());
     }
 
     @Test
@@ -274,9 +245,8 @@ public class IdTokenVerifierTest {
         IdTokenVerifier.Options options = configureOptions(token);
         options.setNonce("nonce");
 
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage(String.format("Nonce (nonce) claim mismatch in the ID token; expected \"%s\", found \"%s\"", expectedNonce, actualNonce));
-        new IdTokenVerifier().verify(token, options);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, options));
+        assertEquals(String.format("Nonce (nonce) claim mismatch in the ID token; expected \"%s\", found \"%s\"", expectedNonce, actualNonce), e.getMessage());
     }
 
     @Test
@@ -285,10 +255,8 @@ public class IdTokenVerifierTest {
 
         IdTokenVerifier.Options options = configureOptions(token);
 
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("Authorized Party (azp) claim must be a string present in the ID token when Audience (aud) claim has multiple values");
-        new IdTokenVerifier().verify(token, options);
-
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, options));
+        assertEquals("Authorized Party (azp) claim must be a string present in the ID token when Audience (aud) claim has multiple values", e.getMessage());
     }
 
     @Test
@@ -299,9 +267,8 @@ public class IdTokenVerifierTest {
 
         IdTokenVerifier.Options options = configureOptions(token);
 
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage(String.format("Authorized Party (azp) claim mismatch in the ID token; expected \"%s\", found \"%s\"", AUDIENCE, actualAzp));
-        new IdTokenVerifier().verify(token, options);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, options));
+        assertEquals(String.format("Authorized Party (azp) claim mismatch in the ID token; expected \"%s\", found \"%s\"", AUDIENCE, actualAzp), e.getMessage());
     }
 
     @Test
@@ -311,9 +278,8 @@ public class IdTokenVerifierTest {
         IdTokenVerifier.Options options = configureOptions(token);
         options.setMaxAge(200);
 
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("Authentication Time (auth_time) claim must be a number present in the ID token when Max Age (max_age) is specified");
-        new IdTokenVerifier().verify(token, options);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, options));
+        assertEquals("Authentication Time (auth_time) claim must be a number present in the ID token when Max Age (max_age) is specified", e.getMessage());
     }
 
     @Test
@@ -331,10 +297,10 @@ public class IdTokenVerifierTest {
         options.setClock(clock);
         options.setMaxAge(maxAge);
 
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage(String.format("Authentication Time (auth_time) claim in the ID token indicates that too much time has passed since the last end-user authentication. Current time (%d) is after last auth at (%d)",
-                clock.getTime() / 1000, actualAuthTime + maxAge + DEFAULT_CLOCK_SKEW));
-        new IdTokenVerifier().verify(token, options);
+        String errorMessage = String.format("Authentication Time (auth_time) claim in the ID token indicates that too much time has passed since the last end-user authentication. Current time (%d) is after last auth at (%d)",
+                clock.getTime() / 1000, actualAuthTime + maxAge + DEFAULT_CLOCK_SKEW);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, options));
+        assertEquals(errorMessage, e.getMessage());
     }
 
     @Test
@@ -371,10 +337,10 @@ public class IdTokenVerifierTest {
         options.setMaxAge(maxAge);
         options.setClockSkew(customLeeway);
 
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage(String.format("Authentication Time (auth_time) claim in the ID token indicates that too much time has passed since the last end-user authentication. Current time (%d) is after last auth at (%d)",
-                clock.getTime() / 1000, actualAuthTime + maxAge + customLeeway));
-        new IdTokenVerifier().verify(token, options);
+        String errorMessage = String.format("Authentication Time (auth_time) claim in the ID token indicates that too much time has passed since the last end-user authentication. Current time (%d) is after last auth at (%d)",
+                clock.getTime() / 1000, actualAuthTime + maxAge + customLeeway);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, options));
+        assertEquals(errorMessage, e.getMessage());
     }
 
     @Test
@@ -480,9 +446,6 @@ public class IdTokenVerifierTest {
 
     @Test
     public void failsWhenOrganizationDoesNotMatchExpected() {
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("Organization (org_id) claim mismatch in the ID token; expected \"org_abc\" but found \"org_123\"");
-
         String token = JWT.create()
                 .withSubject("auth0|sdk458fks")
                 .withAudience(AUDIENCE)
@@ -497,14 +460,12 @@ public class IdTokenVerifierTest {
         IdTokenVerifier.Options opts = configureOptions(jwt);
         opts.setOrganization("org_abc");
 
-        new IdTokenVerifier().verify(token, opts);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, opts));
+        assertEquals("Organization (org_id) claim mismatch in the ID token; expected \"org_abc\" but found \"org_123\"", e.getMessage());
     }
 
     @Test
     public void failsWhenOrganizationExpectedButNotPresent() {
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("Organization Id (org_id) claim must be a string present in the ID token");
-
         String token = JWT.create()
                 .withSubject("auth0|sdk458fks")
                 .withAudience(AUDIENCE)
@@ -518,14 +479,12 @@ public class IdTokenVerifierTest {
         IdTokenVerifier.Options opts = configureOptions(jwt);
         opts.setOrganization("org_123");
 
-        new IdTokenVerifier().verify(token, opts);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, opts));
+        assertEquals("Organization Id (org_id) claim must be a string present in the ID token", e.getMessage());
     }
 
     @Test
     public void failsWhenOrganizationExpectedButClaimIsNotString() {
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("Organization Id (org_id) claim must be a string present in the ID token");
-
         String token = JWT.create()
                 .withSubject("auth0|sdk458fks")
                 .withAudience(AUDIENCE)
@@ -540,7 +499,8 @@ public class IdTokenVerifierTest {
         IdTokenVerifier.Options opts = configureOptions(jwt);
         opts.setOrganization("org_123");
 
-        new IdTokenVerifier().verify(token, opts);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, opts));
+        assertEquals("Organization Id (org_id) claim must be a string present in the ID token", e.getMessage());
     }
 
     @Test

--- a/src/test/java/com/auth0/IdentityVerificationExceptionTest.java
+++ b/src/test/java/com/auth0/IdentityVerificationExceptionTest.java
@@ -1,17 +1,17 @@
 package com.auth0;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class IdentityVerificationExceptionTest {
     private Throwable cause;
     private IdentityVerificationException exception;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         cause = mock(Throwable.class);
         exception = new IdentityVerificationException("error", "description", cause);

--- a/src/test/java/com/auth0/InvalidRequestExceptionMatcher.java
+++ b/src/test/java/com/auth0/InvalidRequestExceptionMatcher.java
@@ -5,32 +5,22 @@ import org.hamcrest.TypeSafeMatcher;
 
 public class InvalidRequestExceptionMatcher extends TypeSafeMatcher<InvalidRequestException> {
 
-    private final String expectedDescription;
     private final String expectedCode;
 
     public static InvalidRequestExceptionMatcher hasCode(String code) {
-        return new InvalidRequestExceptionMatcher(code, null);
-    }
-
-    public static InvalidRequestExceptionMatcher hasDescription(String description) {
-        return new InvalidRequestExceptionMatcher(null, description);
+        return new InvalidRequestExceptionMatcher(code);
     }
 
     private String code;
 
-    private InvalidRequestExceptionMatcher(String expectedCode, String expectedDescription) {
+    private InvalidRequestExceptionMatcher(String expectedCode) {
         this.expectedCode = expectedCode;
-        this.expectedDescription = expectedDescription;
     }
 
     @Override
     protected boolean matchesSafely(InvalidRequestException exception) {
         code = exception.getCode();
-        String description = exception.getMessage();
 
-        if (expectedDescription != null) {
-            return expectedDescription.equals(description);
-        }
         if (expectedCode != null) {
             return expectedCode.equals(code);
         }

--- a/src/test/java/com/auth0/InvalidRequestExceptionTest.java
+++ b/src/test/java/com/auth0/InvalidRequestExceptionTest.java
@@ -1,16 +1,16 @@
 package com.auth0;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class InvalidRequestExceptionTest {
 
     private InvalidRequestException exception;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         exception = new InvalidRequestException("error", "message");
     }

--- a/src/test/java/com/auth0/RandomStorageTest.java
+++ b/src/test/java/com/auth0/RandomStorageTest.java
@@ -1,11 +1,11 @@
 package com.auth0;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class RandomStorageTest {
 

--- a/src/test/java/com/auth0/RequestProcessorTest.java
+++ b/src/test/java/com/auth0/RequestProcessorTest.java
@@ -66,7 +66,6 @@ public class RequestProcessorTest {
     public void shouldThrowOnProcessIfRequestHasError() throws Exception {
         exception.expect(InvalidRequestException.class);
         exception.expect(InvalidRequestExceptionMatcher.hasCode("something happened"));
-        exception.expect(InvalidRequestExceptionMatcher.hasDescription("The request contains an error"));
         exception.expectMessage("The request contains an error");
 
         Map<String, Object> params = new HashMap<>();
@@ -82,7 +81,6 @@ public class RequestProcessorTest {
     public void shouldThrowOnProcessIfRequestHasInvalidState() throws Exception {
         exception.expect(InvalidRequestException.class);
         exception.expect(InvalidRequestExceptionMatcher.hasCode("a0.invalid_state"));
-        exception.expect(InvalidRequestExceptionMatcher.hasDescription("The received state doesn't match the expected one."));
         exception.expectMessage("The received state doesn't match the expected one.");
 
         Map<String, Object> params = new HashMap<>();
@@ -99,7 +97,6 @@ public class RequestProcessorTest {
     public void shouldThrowOnProcessIfRequestHasInvalidStateInSession() throws Exception {
         exception.expect(InvalidRequestException.class);
         exception.expect(InvalidRequestExceptionMatcher.hasCode("a0.invalid_state"));
-        exception.expect(InvalidRequestExceptionMatcher.hasDescription("The received state doesn't match the expected one."));
         exception.expectMessage("The received state doesn't match the expected one.");
 
         Map<String, Object> params = new HashMap<>();
@@ -116,7 +113,6 @@ public class RequestProcessorTest {
     public void shouldThrowOnProcessIfRequestHasMissingStateParameter() throws Exception {
         exception.expect(InvalidRequestException.class);
         exception.expect(InvalidRequestExceptionMatcher.hasCode("a0.invalid_state"));
-        exception.expect(InvalidRequestExceptionMatcher.hasDescription("The received state doesn't match the expected one."));
         exception.expectMessage("The received state doesn't match the expected one.");
 
         MockHttpServletRequest request = getRequest(Collections.emptyMap());
@@ -131,7 +127,6 @@ public class RequestProcessorTest {
     public void shouldThrowOnProcessIfRequestHasMissingStateCookie() throws Exception {
         exception.expect(InvalidRequestException.class);
         exception.expect(InvalidRequestExceptionMatcher.hasCode("a0.invalid_state"));
-        exception.expect(InvalidRequestExceptionMatcher.hasDescription("The received state doesn't match the expected one."));
         exception.expectMessage("The received state doesn't match the expected one.");
 
         Map<String, Object> params = new HashMap<>();
@@ -147,7 +142,6 @@ public class RequestProcessorTest {
     public void shouldThrowOnProcessIfIdTokenRequestIsMissingIdToken() throws Exception {
         exception.expect(InvalidRequestException.class);
         exception.expect(InvalidRequestExceptionMatcher.hasCode("a0.missing_id_token"));
-        exception.expect(InvalidRequestExceptionMatcher.hasDescription("ID Token is missing from the response."));
         exception.expectMessage("ID Token is missing from the response.");
 
         Map<String, Object> params = new HashMap<>();
@@ -164,7 +158,6 @@ public class RequestProcessorTest {
     public void shouldThrowOnProcessIfTokenRequestIsMissingAccessToken() throws Exception {
         exception.expect(InvalidRequestException.class);
         exception.expect(InvalidRequestExceptionMatcher.hasCode("a0.missing_access_token"));
-        exception.expect(InvalidRequestExceptionMatcher.hasDescription("Access Token is missing from the response."));
         exception.expectMessage("Access Token is missing from the response.");
 
         Map<String, Object> params = new HashMap<>();

--- a/src/test/java/com/auth0/SessionUtilsTest.java
+++ b/src/test/java/com/auth0/SessionUtilsTest.java
@@ -1,11 +1,11 @@
 package com.auth0;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SessionUtilsTest {
     @Test

--- a/src/test/java/com/auth0/SessionUtilsTest.java
+++ b/src/test/java/com/auth0/SessionUtilsTest.java
@@ -1,8 +1,6 @@
 package com.auth0;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -10,10 +8,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 public class SessionUtilsTest {
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     @Test
     public void shouldGetAndRemoveAttribute() {
         MockHttpServletRequest req = new MockHttpServletRequest();

--- a/src/test/java/com/auth0/SignatureVerifierTest.java
+++ b/src/test/java/com/auth0/SignatureVerifierTest.java
@@ -135,9 +135,7 @@ public class SignatureVerifierTest {
         exception.expect(TokenValidationException.class);
         exception.expectMessage("Invalid token signature");
         SignatureVerifier verifier = new AsymmetricSignatureVerifier(getRSProvider(RS_PUBLIC_KEY_BAD));
-        DecodedJWT decodedJWT = verifier.verifySignature(RS_JWT);
-
-        assertThat(decodedJWT, notNullValue());
+        verifier.verifySignature(RS_JWT);
     }
 
     @Test

--- a/src/test/java/com/auth0/SignatureVerifierTest.java
+++ b/src/test/java/com/auth0/SignatureVerifierTest.java
@@ -5,9 +5,7 @@ import com.auth0.jwk.JwkException;
 import com.auth0.jwk.JwkProvider;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import org.bouncycastle.util.io.pem.PemReader;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.io.FileInputStream;
 import java.io.FileReader;
@@ -23,7 +21,9 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.Scanner;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -38,43 +38,32 @@ public class SignatureVerifierTest {
     private static final String RS_JWT_INVALID_SIGNATURE = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImFiYzEyMyJ9.eyJub25jZSI6IjEyMzQiLCJpc3MiOiJodHRwczovL21lLmF1dGgwLmNvbS8iLCJhdWQiOiJkYU9nbkdzUlloa3d1NjIxdmYiLCJzdWIiOiJhdXRoMHx1c2VyMTIzIn0.PkPWdoZNfXz8EB0SBPH83lNSOhyhdhdqYIgIwgY2nHozUnFOaUjVewlAXxP_3LBGibQ_ng4s5fEEOCJjaKBy04McryvOuL6nqb1dPQseeyxuv2zQitfrs-7kEtfeS3umywM-tV6guw9_W3nmIgaXOiYiF4WJM23ItbdCmvwdXLaf9-xHkQbRY_zEwEFbprFttKUXFbkPt6XjZ3zZwZbNZn64bx2PBiSJ2KMZAE3Lghmci-RXdhi7hXpmN30Tzze1ZsjvVeRRKNzShByKK9ZGZPmQ5yggJOXFy32ehjGkYwFMCqgMQomcGbcYhsd97huKHMHl3HOE5GDYjIq9o9oABC";
     private static final String HS_JWT_INVALID_SIGNATURE = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJub25jZSI6IjEyMzQiLCJpc3MiOiJodHRwczovL21lLmF1dGgwLmNvbS8iLCJhdWQiOiJkYU9nbkdzUlloa3d1NjIxdmYiLCJzdWIiOiJhdXRoMHx1c2VyMTIzIn0.eTxhYFIHNii1zjxGr9QZvPcqofOd_4bHcjxGq7CQluY";
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     @Test
     public void failsWhenAlgorithmIsNotExpected() {
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("Signature algorithm of \"none\" is not supported. Expected the ID token to be signed with \"[HS256, RS256]\".");
-
         SignatureVerifier verifier = new AlgorithmNameVerifier();
-        verifier.verifySignature(NONE_JWT);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> verifier.verifySignature(NONE_JWT));
+        assertEquals("Signature algorithm of \"none\" is not supported. Expected the ID token to be signed with \"[HS256, RS256]\".", e.getMessage());
     }
 
     @Test
     public void failsWhenTokenCannotBeDecoded() {
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("ID token could not be decoded");
-
         SignatureVerifier verifier = new SymmetricSignatureVerifier("secret");
-        verifier.verifySignature("boom");
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> verifier.verifySignature("boom"));
+        assertEquals("ID token could not be decoded", e.getMessage());
     }
 
     @Test
     public void failsWhenAlgorithmRS256IsNotExpected() {
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("Signature algorithm of \"RS256\" is not supported. Expected the ID token to be signed with \"[HS256]\".");
-
         SignatureVerifier verifier = new SymmetricSignatureVerifier("secret");
-        verifier.verifySignature(RS_JWT);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> verifier.verifySignature(RS_JWT));
+        assertEquals("Signature algorithm of \"RS256\" is not supported. Expected the ID token to be signed with \"[HS256]\".", e.getMessage());
     }
 
     @Test
     public void failsWhenAlgorithmHS256IsNotExpected() throws Exception {
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("Signature algorithm of \"HS256\" is not supported. Expected the ID token to be signed with \"[RS256]\".");
-
         SignatureVerifier verifier = new AsymmetricSignatureVerifier(getRSProvider(RS_PUBLIC_KEY));
-        verifier.verifySignature(HS_JWT);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> verifier.verifySignature(HS_JWT));
+        assertEquals("Signature algorithm of \"HS256\" is not supported. Expected the ID token to be signed with \"[RS256]\".", e.getMessage());
     }
 
     @Test
@@ -115,11 +104,9 @@ public class SignatureVerifierTest {
 
     @Test
     public void failsWithInvalidSignatureHS256Token() {
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("Invalid token signature");
-
         SignatureVerifier verifier = new SymmetricSignatureVerifier("badsecret");
-        verifier.verifySignature(HS_JWT);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> verifier.verifySignature(HS_JWT));
+        assertEquals("Invalid token signature", e.getMessage());
     }
 
     @Test
@@ -132,10 +119,10 @@ public class SignatureVerifierTest {
 
     @Test
     public void failsWithInvalidSignatureRS256Token() throws Exception {
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("Invalid token signature");
         SignatureVerifier verifier = new AsymmetricSignatureVerifier(getRSProvider(RS_PUBLIC_KEY_BAD));
-        verifier.verifySignature(RS_JWT);
+
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> verifier.verifySignature(RS_JWT));
+        assertEquals("Invalid token signature", e.getMessage());
     }
 
     @Test
@@ -143,10 +130,9 @@ public class SignatureVerifierTest {
         JwkProvider  jwkProvider = mock(JwkProvider.class);
         when(jwkProvider.get("abc123")).thenThrow(JwkException.class);
 
-        exception.expect(TokenValidationException.class);
-        exception.expectMessage("Invalid token signature");
         SignatureVerifier verifier = new AsymmetricSignatureVerifier(jwkProvider);
-        verifier.verifySignature(RS_JWT);
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> verifier.verifySignature(RS_JWT));
+        assertEquals("Invalid token signature", e.getMessage());
     }
 
     private JwkProvider getRSProvider(String rsaPath) throws Exception {

--- a/src/test/java/com/auth0/TokensTest.java
+++ b/src/test/java/com/auth0/TokensTest.java
@@ -1,10 +1,10 @@
 package com.auth0;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TokensTest {
 

--- a/src/test/java/com/auth0/TransientCookieStoreTest.java
+++ b/src/test/java/com/auth0/TransientCookieStoreTest.java
@@ -1,8 +1,8 @@
 package com.auth0;
 
 import org.hamcrest.beans.HasPropertyWithValue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -12,14 +12,14 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TransientCookieStoreTest {
 
     private MockHttpServletRequest request;
     private MockHttpServletResponse response;
 
-    @Before
+    @BeforeEach
     public void setup() {
         request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();


### PR DESCRIPTION
### Changes

The project currently uses the outdated JUnit 4.12.
In order to make it easier to write tests and easier for future contributors to easily start working with the project, this PR migrates the test suite to the modern JUnit Jupiter.

Changes included in this patch:

- Build / Gradle:
  - Changed the JUnit dependency from `junit:junit:4.12` to `org.junit.jupiter:junit-jupiter:5.8.1`
  - Added a call to useJUnitPlatform so Gradle will pick up the tests

- Annotations:
  - `org.junit.jupiter.api.Test` was used as a drop-in replacement for `org.junit.Test`
  - `org.junit.jupiter.api.BeforeEach` was used as a drop-in replacement for `org.junit.Before`

 - Assertions:
   - `org.hamcrest.MatcherAssert.assertThat` was used as a drop-in replacement for `org.junit.Assert.assertThat`
   - Tests using the `ExpectedException` `@Rule` were rewritten to use `org.junit.jupiter.api.Assertions#assertThrows`. 
     Note that in some cases the original tests set up the expected exception too early (at the beginning of the test), which could in theory lead to subtle bugs where the expected exception is set up and then the code used to set up the faulty usecase itself throws the exception, and the code that was supposed to be tested is never reached. These mistakes were fixed as part of this refactoring.
   - In the case of `com.auth0.SessionUtilsTest` the `ExpectedException` `@Rule` was present, but was never used, so it was simply removed.

- Miscellaneous
  - `com.auth0.InvalidRequestExceptionMatcher#hasDescription` was always used together with `ExpectedExeption#expectMessage`. Since it duplicated that functionality and added no value, it was removed.
  - `com.auth0.SignatureVerifierTest#failsWithInvalidSignatureRS256Token` had unreachable code which was called after the `verifySignature` call being tested called an exception. Since this was code that could not be reached and served no functional purpose, it was removed.

### References

N / A

### Testing

The PR was tested by running `./gradlew clean test` and observing the same number of tests were executed and none failed.

- [ ] This change adds test coverage
- [X] This change has been tested on the latest version of Java

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
