### PR TITLE
Update java jwt and jwks lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation 'commons-codec:commons-codec:1.15'
 
     api 'com.auth0:auth0:1.32.0'
-    api 'com.auth0:java-jwt:3.18.1'
+    api 'com.auth0:java-jwt:3.18.3'
     api 'com.auth0:jwks-rsa:0.19.0'
 
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.64'

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
 
     api 'com.auth0:auth0:1.32.0'
     api 'com.auth0:java-jwt:3.18.3'
-    api 'com.auth0:jwks-rsa:0.19.0'
+    api 'com.auth0:jwks-rsa:0.20.1'
 
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.64'
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'


### PR DESCRIPTION
### Changes

We are upgrading [java-jwt](https://github.com/auth0/java-jwt) and [jwks-rsa-java](https://github.com/auth0/jwks-rsa-java) library dependency to 3.18.3 and 0.20.1 respectively. This is because of their transitive dependency to vulnerable version of Jackson

### References
[Link](https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698)

### Testing
Since this is a dependency upgrade, we checked it using our existing unit tests