### PR TITLE
Update auth0-java dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation 'com.google.guava:guava-annotations:r03'
     implementation 'commons-codec:commons-codec:1.15'
 
-    api 'com.auth0:auth0:1.32.0'
+    api 'com.auth0:auth0:1.36.1'
     api 'com.auth0:java-jwt:3.18.3'
     api 'com.auth0:jwks-rsa:0.20.1'
 


### PR DESCRIPTION
### Changes

We are upgrading [auth0-java](https://github.com/auth0/auth0-java) library to 1.36.1. This is because of their transitive dependency on the vulnerable version of Jackson

### References
[Link](https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698)

### Testing
Since this is a dependency upgrade, we checked it using our existing unit tests