### PR TITLE
Update auth0 dependencies and address CVE-2020-36518

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,9 +62,9 @@ dependencies {
     implementation 'com.google.guava:guava-annotations:r03'
     implementation 'commons-codec:commons-codec:1.15'
 
-    api 'com.auth0:auth0:1.36.1'
-    api 'com.auth0:java-jwt:3.18.3'
-    api 'com.auth0:jwks-rsa:0.20.1'
+    api 'com.auth0:auth0:1.40.0'
+    api 'com.auth0:java-jwt:3.19.0'
+    api 'com.auth0:jwks-rsa:0.21.0'
 
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.64'
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'


### PR DESCRIPTION
### Changes

This PR bumps the `com.auth0` dependencies to latest versions. This addresses [CVE-2020-36518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518) for the transient `jackson-databind` dependency.

### References
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518