### PR TITLE
Bump transitive jackson dependencies in auth0 libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,9 +62,9 @@ dependencies {
     implementation 'com.google.guava:guava-annotations:r03'
     implementation 'commons-codec:commons-codec:1.15'
 
-    api 'com.auth0:auth0:1.40.0'
-    api 'com.auth0:java-jwt:3.19.0'
-    api 'com.auth0:jwks-rsa:0.21.0'
+    api 'com.auth0:auth0:1.40.1'
+    api 'com.auth0:java-jwt:3.19.1'
+    api 'com.auth0:jwks-rsa:0.21.1'
 
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.64'
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'


### PR DESCRIPTION
This PR bumps the auth0 libraries using jackson-databind dependency to 2.13.2.2 to address [CVE-2020-36518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518) in that library