### PR TITLE
Release 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.9.1](https://github.com/auth0/auth0-java-mvc-common/tree/1.9.1) (2022-03-30)
+[Full Changelog](https://github.com/auth0/auth0-java-mvc-common/compare/1.9.0...1.9.1)
+
+**Security**
+- Bump transitive jackson dependencies in auth0 libraries [\#104](https://github.com/auth0/auth0-java-mvc-common/pull/104) ([poovamraj](https://github.com/poovamraj))
+
 ## [1.9.0](https://github.com/auth0/auth0-java-mvc-common/tree/1.9.0) (2022-03-14)
 [Full Changelog](https://github.com/auth0/auth0-java-mvc-common/compare/1.8.2...1.9.0)
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Via Maven:
 <dependency>
     <groupId>com.auth0</groupId>
     <artifactId>mvc-auth-commons</artifactId>
-    <version>1.9.0</version>
+    <version>1.9.1</version>
 </dependency>
 ```
 
 or Gradle:
 
 ```gradle
-implementation 'com.auth0:mvc-auth-commons:1.9.0'
+implementation 'com.auth0:mvc-auth-commons:1.9.1'
 ```
 
 


### PR DESCRIPTION
## [1.9.1](https://github.com/auth0/auth0-java-mvc-common/tree/1.9.1) (2022-03-30)
[Full Changelog](https://github.com/auth0/auth0-java-mvc-common/compare/1.9.0...1.9.1)

**Security**
- Bump transitive jackson dependencies in auth0 libraries [\#104](https://github.com/auth0/auth0-java-mvc-common/pull/104) ([poovamraj](https://github.com/poovamraj))