### PR TITLE
Update OkHttp version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,5 +72,5 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.8.9'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
     testImplementation 'org.springframework:spring-test:4.3.14.RELEASE'
-    testImplementation 'com.squareup.okhttp3:okhttp:4.9.0'
+    testImplementation 'com.squareup.okhttp3:okhttp:4.9.3'
 }


### PR DESCRIPTION
### Changes

Patch to latest version of OkHttp (only used directly for test dependency). We will also the implementation dependency of `auth0-java` once a new release is available containing [this fix](https://github.com/auth0/auth0-java/pull/417) to address [CVE-2021-0341](https://nvd.nist.gov/vuln/detail/CVE-2021-0341)