### PR TITLE
Update auth0-java dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation 'com.google.guava:guava-annotations:r03'
     implementation 'commons-codec:commons-codec:1.15'
 
-    api 'com.auth0:auth0:1.40.1'
+    api 'com.auth0:auth0:1.40.2'
     api 'com.auth0:java-jwt:3.19.1'
     api 'com.auth0:jwks-rsa:0.21.1'
 


### PR DESCRIPTION
Updates `auth0-java` to v1.40.2 to address [CVE-2021-0341](https://nvd.nist.gov/vuln/detail/CVE-2021-0341)