### PR TITLE
Update to Gradle 6.9.2 and bump OSS plugin version

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,7 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id 'com.auth0.gradle.oss-library.java' version '0.16.0'
+        id 'com.auth0.gradle.oss-library.java' version '0.17.2'
     }
 }
 


### PR DESCRIPTION
Updates the Gradle wrapper to v6.9.2. This resolves a few M1-specific bugs.