### PR TITLE
[SDK-4146] Support configurable cookie path

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,7 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id 'com.auth0.gradle.oss-library.java' version '0.17.2'
+        id 'com.auth0.gradle.oss-library.java' version '0.18.0'
     }
 }
 

--- a/src/main/java/com/auth0/AuthCookie.java
+++ b/src/main/java/com/auth0/AuthCookie.java
@@ -22,6 +22,7 @@ class AuthCookie {
     private final String value;
     private boolean secure;
     private SameSite sameSite;
+    private String cookiePath;
 
     /**
      * Create a new instance.
@@ -35,6 +36,10 @@ class AuthCookie {
 
         this.key = key;
         this.value = value;
+    }
+
+    void setPath(String path) {
+        this.cookiePath = path;
     }
 
     /**
@@ -64,6 +69,9 @@ class AuthCookie {
      */
     String buildHeaderString() {
         String baseCookieString = String.format("%s=%s; HttpOnly; Max-Age=%d", encode(key), encode(value), MAX_AGE_SECONDS);
+        if (cookiePath != null) {
+            baseCookieString = baseCookieString.concat(String.format("; Path=%s", cookiePath));
+        }
         if (sameSite != null) {
             baseCookieString = baseCookieString.concat(String.format("; SameSite=%s", encode(sameSite.getValue())));
         }

--- a/src/main/java/com/auth0/AuthenticationController.java
+++ b/src/main/java/com/auth0/AuthenticationController.java
@@ -62,6 +62,7 @@ public class AuthenticationController {
         private String organization;
         private String invitation;
         private HttpOptions httpOptions;
+        private String cookiePath;
 
         Builder(String domain, String clientId, String clientSecret) {
             Validate.notNull(domain);
@@ -84,6 +85,19 @@ public class AuthenticationController {
         public Builder withHttpOptions(HttpOptions httpOptions) {
             Validate.notNull(httpOptions);
             this.httpOptions = httpOptions;
+            return this;
+        }
+
+        /**
+         * Specify that transient authentication-based cookies such as state and nonce are created with the specified
+         * {@code Path} cookie attribute.
+         *
+         * @param cookiePath the path to set on the cookie.
+         * @return this builder instance.
+         */
+        public Builder withCookiePath(String cookiePath) {
+            Validate.notNull(cookiePath);
+            this.cookiePath = cookiePath;
             return this;
         }
 
@@ -208,6 +222,7 @@ public class AuthenticationController {
                     .withLegacySameSiteCookie(useLegacySameSiteCookie)
                     .withOrganization(organization)
                     .withInvitation(invitation)
+                    .withCookiePath(cookiePath)
                     .build();
 
             return new AuthenticationController(processor);

--- a/src/main/java/com/auth0/AuthorizeUrl.java
+++ b/src/main/java/com/auth0/AuthorizeUrl.java
@@ -28,6 +28,8 @@ public class AuthorizeUrl {
     private String nonce;
     private String state;
     private final AuthAPI authAPI;
+    private String cookiePath;
+
     private boolean used;
     private Map<String, String> params;
     private final String redirectUri;
@@ -127,6 +129,16 @@ public class AuthorizeUrl {
      */
     public AuthorizeUrl withAudience(String audience) {
         params.put("audience", audience);
+        return this;
+    }
+
+    /**
+     * Sets the value of the Path cookie attribute
+     * @param cookiePath the cookie path to set
+     * @return
+     */
+    AuthorizeUrl withCookiePath(String cookiePath) {
+        this.cookiePath = cookiePath;
         return this;
     }
 
@@ -234,8 +246,8 @@ public class AuthorizeUrl {
         if (response != null) {
             SameSite sameSiteValue = containsFormPost() ? SameSite.NONE : SameSite.LAX;
 
-            TransientCookieStore.storeState(response, state, sameSiteValue, useLegacySameSiteCookie, setSecureCookie);
-            TransientCookieStore.storeNonce(response, nonce, sameSiteValue, useLegacySameSiteCookie, setSecureCookie);
+            TransientCookieStore.storeState(response, state, sameSiteValue, useLegacySameSiteCookie, setSecureCookie, cookiePath);
+            TransientCookieStore.storeNonce(response, nonce, sameSiteValue, useLegacySameSiteCookie, setSecureCookie, cookiePath);
         }
 
         // Also store in Session just in case developer uses deprecated

--- a/src/test/java/com/auth0/AuthenticationControllerTest.java
+++ b/src/test/java/com/auth0/AuthenticationControllerTest.java
@@ -565,4 +565,22 @@ public class AuthenticationControllerTest {
                 () -> AuthenticationController.newBuilder("DOMAIN", "CLIENT_ID", "SECRET")
                         .withInvitation(null));
     }
+
+    @Test
+    public void shouldConfigureCookiePath() {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        AuthenticationController controller = AuthenticationController.newBuilder("domain", "clientId", "clientSecret")
+                .withCookiePath("/Path")
+                .build();
+
+        controller.buildAuthorizeUrl(new MockHttpServletRequest(), response, "https://redirect.uri/here")
+                .withState("state")
+                .build();
+
+        List<String> headers = response.getHeaders("Set-Cookie");
+
+        assertThat(headers.size(), is(1));
+        assertThat(headers, everyItem(is("com.auth0.state=state; HttpOnly; Max-Age=600; Path=/Path; SameSite=Lax")));
+    }
 }

--- a/src/test/java/com/auth0/TransientCookieStoreTest.java
+++ b/src/test/java/com/auth0/TransientCookieStoreTest.java
@@ -27,7 +27,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldNotSetCookieIfStateIsNull() {
-        TransientCookieStore.storeState(response, null, SameSite.NONE, true, false);
+        TransientCookieStore.storeState(response, null, SameSite.NONE, true, false, null);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(0));
@@ -35,7 +35,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldNotSetCookieIfNonceIsNull() {
-        TransientCookieStore.storeNonce(response, null, SameSite.NONE, true, false);
+        TransientCookieStore.storeNonce(response, null, SameSite.NONE, true, false, null);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(0));
@@ -44,7 +44,7 @@ public class TransientCookieStoreTest {
     @Test
     public void shouldHandleSpecialCharsWhenStoringState() throws Exception {
         String stateVal = ";state = ,va\\lu;e\"";
-        TransientCookieStore.storeState(response, stateVal, SameSite.NONE, true, false);
+        TransientCookieStore.storeState(response, stateVal, SameSite.NONE, true, false, null);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
@@ -54,13 +54,11 @@ public class TransientCookieStoreTest {
                 String.format("com.auth0.state=%s; HttpOnly; Max-Age=600; SameSite=None; Secure", expectedEncodedState)));
         assertThat(headers, hasItem(
                 String.format("_com.auth0.state=%s; HttpOnly; Max-Age=600", expectedEncodedState)));
-        System.out.println("headers size: " + headers.size());
-        System.out.println("header: " + headers.get(0));
     }
 
     @Test
     public void shouldSetStateSameSiteCookieAndFallbackCookie() {
-        TransientCookieStore.storeState(response, "123456", SameSite.NONE, true, false);
+        TransientCookieStore.storeState(response, "123456", SameSite.NONE, true, false, null);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
@@ -71,7 +69,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldSetStateSameSiteCookieAndNoFallbackCookie() {
-        TransientCookieStore.storeState(response, "123456", SameSite.NONE, false, false);
+        TransientCookieStore.storeState(response, "123456", SameSite.NONE, false, false, null);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));
@@ -81,7 +79,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldSetSecureCookieWhenSameSiteLaxAndConfigured() {
-        TransientCookieStore.storeState(response, "123456", SameSite.LAX, true, true);
+        TransientCookieStore.storeState(response, "123456", SameSite.LAX, true, true, null);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));
@@ -91,7 +89,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldSetSecureFallbackCookieWhenSameSiteNoneAndConfigured() {
-        TransientCookieStore.storeState(response, "123456", SameSite.NONE, true, true);
+        TransientCookieStore.storeState(response, "123456", SameSite.NONE, true, true, null);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
@@ -102,7 +100,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldNotSetSecureCookieWhenSameSiteLaxAndConfigured() {
-        TransientCookieStore.storeState(response, "123456", SameSite.LAX, true, false);
+        TransientCookieStore.storeState(response, "123456", SameSite.LAX, true, false, null);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));
@@ -112,7 +110,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldSetNonceSameSiteCookieAndFallbackCookie() {
-        TransientCookieStore.storeNonce(response, "123456", SameSite.NONE, true, false);
+        TransientCookieStore.storeNonce(response, "123456", SameSite.NONE, true, false, null);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
@@ -123,7 +121,7 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldSetNonceSameSiteCookieAndNoFallbackCookie() {
-        TransientCookieStore.storeNonce(response, "123456", SameSite.NONE, false, false);
+        TransientCookieStore.storeNonce(response, "123456", SameSite.NONE, false, false, null);
 
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));
@@ -138,7 +136,7 @@ public class TransientCookieStoreTest {
 
         request.setCookies(cookie1, cookie2);
 
-        String state = TransientCookieStore.getState(request, response, true);
+        String state = TransientCookieStore.getState(request, response);
         assertThat(state, is("123456"));
 
         Cookie[] cookies = response.getCookies();
@@ -157,7 +155,7 @@ public class TransientCookieStoreTest {
 
         request.setCookies(cookie1);
 
-        String state = TransientCookieStore.getState(request, response, false);
+        String state = TransientCookieStore.getState(request, response);
         assertThat(state, is("123456"));
 
         Cookie[] cookies = response.getCookies();
@@ -175,7 +173,7 @@ public class TransientCookieStoreTest {
 
         request.setCookies(cookie1);
 
-        String state = TransientCookieStore.getState(request, response, true);
+        String state = TransientCookieStore.getState(request, response);
         assertThat(state, is("123456"));
 
         Cookie[] cookies = response.getCookies();
@@ -194,7 +192,7 @@ public class TransientCookieStoreTest {
 
         request.setCookies(cookie1, cookie2);
 
-        String state = TransientCookieStore.getNonce(request, response, true);
+        String state = TransientCookieStore.getNonce(request, response);
         assertThat(state, is("123456"));
 
         Cookie[] cookies = response.getCookies();
@@ -212,7 +210,7 @@ public class TransientCookieStoreTest {
 
         request.setCookies(cookie1);
 
-        String state = TransientCookieStore.getNonce(request, response, true);
+        String state = TransientCookieStore.getNonce(request, response);
         assertThat(state, is("123456"));
 
         Cookie[] cookies = response.getCookies();
@@ -230,7 +228,7 @@ public class TransientCookieStoreTest {
 
         request.setCookies(cookie1);
 
-        String state = TransientCookieStore.getNonce(request, response, true);
+        String state = TransientCookieStore.getNonce(request, response);
         assertThat(state, is("123456"));
 
         Cookie[] cookies = response.getCookies();
@@ -244,13 +242,13 @@ public class TransientCookieStoreTest {
 
     @Test
     public void shouldReturnEmptyStateWhenNoCookies() {
-        String state = TransientCookieStore.getState(request, response, true);
+        String state = TransientCookieStore.getState(request, response);
         assertThat(state, is(nullValue()));
     }
 
     @Test
     public void shouldReturnEmptyNonceWhenNoCookies() {
-        String nonce = TransientCookieStore.getNonce(request, response, true);
+        String nonce = TransientCookieStore.getNonce(request, response);
         assertThat(nonce, is(nullValue()));
     }
 
@@ -259,7 +257,7 @@ public class TransientCookieStoreTest {
         Cookie cookie1 = new Cookie("someCookie", "123456");
         request.setCookies(cookie1);
 
-        String state = TransientCookieStore.getState(request, response, true);
+        String state = TransientCookieStore.getState(request, response);
         assertThat(state, is(nullValue()));
     }
 
@@ -268,7 +266,7 @@ public class TransientCookieStoreTest {
         Cookie cookie1 = new Cookie("someCookie", "123456");
         request.setCookies(cookie1);
 
-        String nonce = TransientCookieStore.getNonce(request, response, true);
+        String nonce = TransientCookieStore.getNonce(request, response);
         assertThat(nonce, is(nullValue()));
         assertThat(nonce, is(nullValue()));
     }


### PR DESCRIPTION
### Changes

Prior to this change, transient authentication cookies (state, nonce), are set without a `Path` attribute, which makes them available in the "directory" of the current path.

For customers with login routes outside the path of the callback path, this will result in login failure when attempting to validate the state/nonce.

This change introduces a configuration option on `AuthenticationController`, `withCookiePath(String cookiePath)`, that enables customers to specify a path for the cookies. If not specified, the default path will be used (e.g., no path set, thus the "directory" of the current URL).

### References

https://auth0team.atlassian.net/browse/ESD-27518

### Testing

In addition to the unit tests, testing was done with an application provided by a customer demonstrating the issue:

* A login servlet that handles logins from `/Product/login` and `/Product/org/login`
* A callback handler servlet at `/Product/app/redirectUri`

Prior to the change, it was not possible to login from `/Product/org/login`, as cookies would only be available from the `/Product/org` path. 

With this change, specifying `withCookiePath("/Product")` or `withCookiePath("/")` enables login to work as the cookies will be available when validating the state/nonce.