### PR TITLE
[SDK-4401] Support using organization name

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -26,7 +26,7 @@ Note that Organizations is currently only available to customers on our Enterpri
 
 ### Log in to an organization
 
-Log in to an organization by using `withOrganization()` when configuring the `AuthenticationController`:
+Log in to an organization by using `withOrganization()` when configuring the `AuthenticationController`, passing either the organization ID or organization name:
 
 ```java
 AuthenticationController controller = AuthenticationController.newBuilder("YOUR-AUTH0-DOMAIN", "YOUR-CLIENT-ID", "YOUR-CLIENT-SECRET")
@@ -34,15 +34,15 @@ AuthenticationController controller = AuthenticationController.newBuilder("YOUR-
         .build();
 ```
 
-When logging into an organization, this library will validate that the `org_id` claim of the ID Token matches the value configured.
+When logging into an organization, this library will validate that the `org_id` or `org_name` claim of the ID Token matches the value configured.
 
-If no organization parameter was given to the authorization endpoint, but an `org_id` claim is present in the ID Token, then the claim should be validated by the application to ensure that the value received is expected or known.
+If no organization parameter was given to the authorization endpoint, but an `org_id` or `org_name` claim is present in the ID Token, then the claim should be validated by the application to ensure that the value received is expected or known.
 
 Normally, validating the issuer would be enough to ensure that the token was issued by Auth0, and this check is performed by this SDK.
 In the case of organizations, additional checks may be required so that the organization within an Auth0 tenant is expected.
 
-In particular, the `org_id` claim should be checked to ensure it is a value that is already known to the application.
-This could be validated against a known list of organization IDs, or perhaps checked in conjunction with the current request URL (e.g., the sub-domain may hint at what organization should be used to validate the ID Token).
+In particular, the `org_id` or `org_name` claim should be checked to ensure it is a value that is already known to the application.
+This could be validated against a known list of organizations, or perhaps checked in conjunction with the current request URL (e.g., the sub-domain may hint at what organization should be used to validate the ID Token).
 
 If the claim cannot be validated, then the application should deem the token invalid.
 The following example demonstrates this, using the [java-jwt](https://github.com/auth0/java-jwt) library:

--- a/src/main/java/com/auth0/AuthenticationController.java
+++ b/src/main/java/com/auth0/AuthenticationController.java
@@ -167,7 +167,7 @@ public class AuthenticationController {
         /**
          * Sets the organization query string parameter value used to login to an organization.
          *
-         * @param organization The ID of the organization to log the user in to.
+         * @param organization The ID or name of the organization to log the user in to.
          * @return the builder instance.
          */
         public Builder withOrganization(String organization) {

--- a/src/test/java/com/auth0/IdTokenVerifierTest.java
+++ b/src/test/java/com/auth0/IdTokenVerifierTest.java
@@ -426,7 +426,121 @@ public class IdTokenVerifierTest {
     }
 
     @Test
-    public void succeedsWhenOrganizationMatchesExpected() {
+    public void succeedsWhenOrganizationNameMatchesExpected() {
+        String token = JWT.create()
+                .withSubject("auth0|sdk458fks")
+                .withAudience(AUDIENCE)
+                .withIssuedAt(getYesterday())
+                .withExpiresAt(getTomorrow())
+                .withIssuer("https://" + DOMAIN + "/")
+                .withClaim("org_name", "my org")
+                .sign(Algorithm.HMAC256("secret"));
+
+        String jwt = JWT.decode(token).getToken();
+
+        IdTokenVerifier.Options opts = configureOptions(jwt);
+        opts.setOrganization("my org");
+
+        new IdTokenVerifier().verify(token, opts);
+    }
+
+    @Test
+    public void failsWhenOrganizationNameDoesNotMatchExpected() {
+        String token = JWT.create()
+                .withSubject("auth0|sdk458fks")
+                .withAudience(AUDIENCE)
+                .withIssuedAt(getYesterday())
+                .withExpiresAt(getTomorrow())
+                .withIssuer("https://" + DOMAIN + "/")
+                .withClaim("org_name", "my org")
+                .sign(Algorithm.HMAC256("secret"));
+
+        String jwt = JWT.decode(token).getToken();
+
+        IdTokenVerifier.Options opts = configureOptions(jwt);
+        opts.setOrganization("other org");
+
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, opts));
+        assertEquals("Organization (org_name) claim mismatch in the ID token; expected \"other org\" but found \"my org\"", e.getMessage());
+    }
+
+    @Test
+    public void succeedsWhenOrganizationNameDoesNotMatchExpected_caseInsensitive() {
+        String token = JWT.create()
+                .withSubject("auth0|sdk458fks")
+                .withAudience(AUDIENCE)
+                .withIssuedAt(getYesterday())
+                .withExpiresAt(getTomorrow())
+                .withIssuer("https://" + DOMAIN + "/")
+                .withClaim("org_name", "my org")
+                .sign(Algorithm.HMAC256("secret"));
+
+        String jwt = JWT.decode(token).getToken();
+
+        IdTokenVerifier.Options opts = configureOptions(jwt);
+        opts.setOrganization("My org");
+
+        new IdTokenVerifier().verify(token, opts);
+    }
+
+    @Test
+    public void failsWhenOrganizationNameExpectedButNotPresent() {
+        String token = JWT.create()
+                .withSubject("auth0|sdk458fks")
+                .withAudience(AUDIENCE)
+                .withIssuedAt(getYesterday())
+                .withExpiresAt(getTomorrow())
+                .withIssuer("https://" + DOMAIN + "/")
+                .sign(Algorithm.HMAC256("secret"));
+
+        String jwt = JWT.decode(token).getToken();
+
+        IdTokenVerifier.Options opts = configureOptions(jwt);
+        opts.setOrganization("my org");
+
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, opts));
+        assertEquals("Organization name (org_name) claim must be a string present in the ID token", e.getMessage());
+    }
+
+    @Test
+    public void failsWhenOrganizationNameExpectedButClaimIsNotString() {
+        String token = JWT.create()
+                .withSubject("auth0|sdk458fks")
+                .withAudience(AUDIENCE)
+                .withIssuedAt(getYesterday())
+                .withExpiresAt(getTomorrow())
+                .withIssuer("https://" + DOMAIN + "/")
+                .withClaim("org_name", 42)
+                .sign(Algorithm.HMAC256("secret"));
+
+        String jwt = JWT.decode(token).getToken();
+
+        IdTokenVerifier.Options opts = configureOptions(jwt);
+        opts.setOrganization("my org");
+
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, opts));
+        assertEquals("Organization name (org_name) claim must be a string present in the ID token", e.getMessage());
+    }
+
+    @Test
+    public void succeedsWhenOrganizationNameNotSpecifiedButIsPresent() {
+        String token = JWT.create()
+                .withSubject("auth0|sdk458fks")
+                .withAudience(AUDIENCE)
+                .withIssuedAt(getYesterday())
+                .withExpiresAt(getTomorrow())
+                .withIssuer("https://" + DOMAIN + "/")
+                .withClaim("org_name", "my org")
+                .sign(Algorithm.HMAC256("secret"));
+
+        String jwt = JWT.decode(token).getToken();
+
+        IdTokenVerifier.Options opts = configureOptions(jwt);
+        new IdTokenVerifier().verify(token, opts);
+    }
+
+    @Test
+    public void succeedsWhenOrganizationIdMatchesExpected() {
         String token = JWT.create()
                 .withSubject("auth0|sdk458fks")
                 .withAudience(AUDIENCE)
@@ -445,7 +559,7 @@ public class IdTokenVerifierTest {
     }
 
     @Test
-    public void failsWhenOrganizationDoesNotMatchExpected() {
+    public void failsWhenOrganizationIdDoesNotMatchExpected() {
         String token = JWT.create()
                 .withSubject("auth0|sdk458fks")
                 .withAudience(AUDIENCE)
@@ -465,7 +579,27 @@ public class IdTokenVerifierTest {
     }
 
     @Test
-    public void failsWhenOrganizationExpectedButNotPresent() {
+    public void failsWhenOrganizationIdDoesNotMatchExpected_caseSensitive() {
+        String token = JWT.create()
+                .withSubject("auth0|sdk458fks")
+                .withAudience(AUDIENCE)
+                .withIssuedAt(getYesterday())
+                .withExpiresAt(getTomorrow())
+                .withIssuer("https://" + DOMAIN + "/")
+                .withClaim("org_id", "org_123")
+                .sign(Algorithm.HMAC256("secret"));
+
+        String jwt = JWT.decode(token).getToken();
+
+        IdTokenVerifier.Options opts = configureOptions(jwt);
+        opts.setOrganization("org_aBc");
+
+        TokenValidationException e = assertThrows(TokenValidationException.class, () -> new IdTokenVerifier().verify(token, opts));
+        assertEquals("Organization (org_id) claim mismatch in the ID token; expected \"org_aBc\" but found \"org_123\"", e.getMessage());
+    }
+
+    @Test
+    public void failsWhenOrganizationIdExpectedButNotPresent() {
         String token = JWT.create()
                 .withSubject("auth0|sdk458fks")
                 .withAudience(AUDIENCE)
@@ -484,7 +618,7 @@ public class IdTokenVerifierTest {
     }
 
     @Test
-    public void failsWhenOrganizationExpectedButClaimIsNotString() {
+    public void failsWhenOrganizationIdExpectedButClaimIsNotString() {
         String token = JWT.create()
                 .withSubject("auth0|sdk458fks")
                 .withAudience(AUDIENCE)
@@ -504,7 +638,7 @@ public class IdTokenVerifierTest {
     }
 
     @Test
-    public void succeedsWhenOrganizationNotSpecifiedButIsPresent() {
+    public void succeedsWhenOrganizationIdNotSpecifiedButIsPresent() {
         String token = JWT.create()
                 .withSubject("auth0|sdk458fks")
                 .withAudience(AUDIENCE)


### PR DESCRIPTION
Adds support for specifying the organization name to be used on the authorize request (in addition to organization ID).

In addition to the unit tests, the change was tested on a tenant enabling the use of the organization name (as well as organization ID).