### PR TITLE
Fix org name validation

### DIFF
--- a/src/main/java/com/auth0/IdTokenVerifier.java
+++ b/src/main/java/com/auth0/IdTokenVerifier.java
@@ -74,7 +74,7 @@ class IdTokenVerifier {
                 if (isEmpty(orgNameClaim)) {
                     throw new TokenValidationException("Organization name (org_name) claim must be a string present in the ID token");
                 }
-                if (!org.equalsIgnoreCase(orgNameClaim)) {
+                if (!org.toLowerCase().equals(orgNameClaim)) {
                     throw new TokenValidationException(String.format("Organization (org_name) claim mismatch in the ID token; expected \"%s\" but found \"%s\"", verifyOptions.organization, orgNameClaim));
                 }
             }


### PR DESCRIPTION
### Changes

In #132, we validate the org name by using `equalsIgnoreCase()`, but instead we should use `equals()` with the provided value being lower-cased. The AS will send the claim value as lower-cased.