### PR TITLE
Upgrade to JDK 17 and JakartaEE 6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ oss {
     }
 }
 
+jacoco {
+    toolVersion = "0.8.8"
+}
+
 jacocoTestReport {
     reports {
         xml.enabled = true
@@ -40,22 +44,13 @@ jacocoTestReport {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(8)
-    }
-    // Needed because of broken gradle metadata, see https://github.com/google/guava/issues/6612#issuecomment-1614992368
-    sourceSets.all {
-        configurations.getByName(runtimeClasspathConfigurationName) {
-            attributes.attribute(Attribute.of("org.gradle.jvm.environment", String), "standard-jvm")
-        }
-        configurations.getByName(compileClasspathConfigurationName) {
-            attributes.attribute(Attribute.of("org.gradle.jvm.environment", String), "standard-jvm")
-        }
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 
 compileJava {
-    sourceCompatibility '1.8'
-    targetCompatibility '1.8'
+    sourceCompatibility '17'
+    targetCompatibility '17'
 }
 
 test {
@@ -67,7 +62,7 @@ test {
 }
 
 dependencies {
-    implementation 'javax.servlet:javax.servlet-api:3.1.0'
+    implementation 'jakarta.servlet:jakarta.servlet-api:6.0.0'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'com.google.guava:guava-annotations:r03'
     implementation 'commons-codec:commons-codec:1.15'
@@ -79,9 +74,14 @@ dependencies {
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.64'
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'
     testImplementation 'org.hamcrest:hamcrest-core:1.3'
-    testImplementation 'org.mockito:mockito-core:2.8.9'
+    // https://mvnrepository.com/artifact/org.mockito/mockito-core
+testImplementation 'org.mockito:mockito-core:4.11.0'
+
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
-    testImplementation 'org.springframework:spring-test:4.3.14.RELEASE'
+  // https://mvnrepository.com/artifact/org.springframework/spring-test
+testImplementation 'org.springframework:spring-test:6.0.14'
+
+testImplementation 'org.springframework:spring-web:6.0.14'
     testImplementation 'com.squareup.okhttp3:okhttp:4.11.0'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+netbeans.hint.jdkPlatform=JDK_11__System_

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/auth0/AuthenticationController.java
+++ b/src/main/java/com/auth0/AuthenticationController.java
@@ -7,8 +7,8 @@ import com.auth0.net.Telemetry;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.Validate;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 
 /**
@@ -317,7 +317,7 @@ public class AuthenticationController {
      * when building the {@link AuthorizeUrl} that the user will be redirected to to login. Failure to do so may result
      * in a broken login experience for the user.</p>
      *
-     * @deprecated This method uses the {@link javax.servlet.http.HttpSession} for auth-based data, and is incompatible
+     * @deprecated This method uses the {@link jakarta.servlet.http.HttpSession} for auth-based data, and is incompatible
      * with clients that are using the "id_token" or "token" responseType with browsers that enforce SameSite cookie
      * restrictions. This method will be removed in version 2.0.0. Use
      * {@link AuthenticationController#handle(HttpServletRequest, HttpServletResponse)} instead.
@@ -341,7 +341,7 @@ public class AuthenticationController {
      * {@link AuthenticationController#handle(HttpServletRequest)} method. Failure to do so may result in a broken login
      * experience for users.</p>
      *
-     * @deprecated This method stores data in the {@link javax.servlet.http.HttpSession}, and is incompatible with clients
+     * @deprecated This method stores data in the {@link jakarta.servlet.http.HttpSession}, and is incompatible with clients
      * that are using the "id_token" or "token" responseType with browsers that enforce SameSite cookie restrictions.
      * This method will be removed in version 2.0.0. Use
      * {@link AuthenticationController#buildAuthorizeUrl(HttpServletRequest, HttpServletResponse, String)} instead.

--- a/src/main/java/com/auth0/AuthorizeUrl.java
+++ b/src/main/java/com/auth0/AuthorizeUrl.java
@@ -5,8 +5,8 @@ import com.auth0.client.auth.AuthorizeUrlBuilder;
 import com.auth0.exception.Auth0Exception;
 import com.auth0.json.auth.PushedAuthorizationResponse;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.*;
 
 import static com.auth0.IdentityVerificationException.API_ERROR;
@@ -39,7 +39,7 @@ public class AuthorizeUrl {
      *
      * Using this constructor with a non-null {@link HttpServletResponse} will store the state and nonce as
      * cookies when the {@link AuthorizeUrl#build()} method is called, with the appropriate SameSite attribute depending
-     * on the responseType. State and nonce will also be stored in the {@link javax.servlet.http.HttpSession} as a fallback,
+     * on the responseType. State and nonce will also be stored in the {@link jakarta.servlet.http.HttpSession} as a fallback,
      * but this behavior will be removed in a future release, and only cookies will be used.
      *
      * @param client       the Auth0 Authentication API client

--- a/src/main/java/com/auth0/RandomStorage.java
+++ b/src/main/java/com/auth0/RandomStorage.java
@@ -1,7 +1,7 @@
 package com.auth0;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 
 class RandomStorage extends SessionUtils {
 

--- a/src/main/java/com/auth0/RequestProcessor.java
+++ b/src/main/java/com/auth0/RequestProcessor.java
@@ -5,8 +5,8 @@ import com.auth0.exception.Auth0Exception;
 import com.auth0.json.auth.TokenHolder;
 import org.apache.commons.lang3.Validate;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.List;
 

--- a/src/main/java/com/auth0/SessionUtils.java
+++ b/src/main/java/com/auth0/SessionUtils.java
@@ -2,8 +2,8 @@ package com.auth0;
 
 import org.apache.commons.lang3.Validate;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 
 /**
  * Helper class to handle easy session key-value storage.

--- a/src/main/java/com/auth0/TransientCookieStore.java
+++ b/src/main/java/com/auth0/TransientCookieStore.java
@@ -2,9 +2,9 @@ package com.auth0;
 
 import org.apache.commons.lang3.Validate;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;

--- a/src/test/java/com/auth0/AuthenticationControllerTest.java
+++ b/src/test/java/com/auth0/AuthenticationControllerTest.java
@@ -16,8 +16,8 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/com/auth0/AuthenticationControllerTest.java
+++ b/src/test/java/com/auth0/AuthenticationControllerTest.java
@@ -412,7 +412,7 @@ public class AuthenticationControllerTest {
         List<String> headers = response.getHeaders("Set-Cookie");
 
         assertThat(headers.size(), is(1));
-        assertThat(headers, everyItem(matchesPattern("com.auth0.state=state; Max-Age=600; Expires=.*?; HttpOnly; SameSite=Lax")));
+        assertThat(headers, everyItem(matchesPattern("com\\.auth0\\.state=state; Max-Age=600; Expires=.*?; HttpOnly; SameSite=Lax")));
     }
 
     @Test
@@ -431,10 +431,10 @@ public class AuthenticationControllerTest {
         List<String> headers = response.getHeaders("Set-Cookie");
 
         assertThat(headers.size(), is(4));
-        assertThat(headers, hasItem(matchesPattern("com.auth0.state=state; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
-        assertThat(headers, hasItem(matchesPattern("_com.auth0.state=state; Max-Age=600; Expires=.*?; HttpOnly")));
-        assertThat(headers, hasItem(matchesPattern("com.auth0.nonce=nonce; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
-        assertThat(headers, hasItem(matchesPattern("_com.auth0.nonce=nonce; Max-Age=600; Expires=.*?; HttpOnly")));
+        assertThat(headers, hasItem(matchesPattern("com\\.auth0\\.state=state; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
+        assertThat(headers, hasItem(matchesPattern("_com\\.auth0\\.state=state; Max-Age=600; Expires=.*?; HttpOnly")));
+        assertThat(headers, hasItem(matchesPattern("com\\.auth0\\.nonce=nonce; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
+        assertThat(headers, hasItem(matchesPattern("_com\\.auth0\\.nonce=nonce; Max-Age=600; Expires=.*?; HttpOnly")));
     }
 
     @Test
@@ -454,8 +454,8 @@ public class AuthenticationControllerTest {
         List<String> headers = response.getHeaders("Set-Cookie");
 
         assertThat(headers.size(), is(2));
-        assertThat(headers, hasItem(matchesPattern("com.auth0.state=state; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
-        assertThat(headers, hasItem(matchesPattern("com.auth0.nonce=nonce; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
+        assertThat(headers, hasItem(matchesPattern("com\\.auth0\\.state=state; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
+        assertThat(headers, hasItem(matchesPattern("com\\.auth0\\.nonce=nonce; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
     }
 
     @Test
@@ -581,6 +581,6 @@ public class AuthenticationControllerTest {
         List<String> headers = response.getHeaders("Set-Cookie");
 
         assertThat(headers.size(), is(1));
-        assertThat(headers, everyItem(matchesPattern("com.auth0.state=state; Path=/Path; Max-Age=600; Expires=.*?; HttpOnly; SameSite=Lax")));
+        assertThat(headers, everyItem(matchesPattern("com\\.auth0\\.state=state; Path=/Path; Max-Age=600; Expires=.*?; HttpOnly; SameSite=Lax")));
     }
 }

--- a/src/test/java/com/auth0/AuthenticationControllerTest.java
+++ b/src/test/java/com/auth0/AuthenticationControllerTest.java
@@ -412,7 +412,7 @@ public class AuthenticationControllerTest {
         List<String> headers = response.getHeaders("Set-Cookie");
 
         assertThat(headers.size(), is(1));
-        assertThat(headers, everyItem(is("com.auth0.state=state; HttpOnly; Max-Age=600; SameSite=Lax")));
+        assertThat(headers, everyItem(matchesPattern("com.auth0.state=state; Max-Age=600; Expires=.*?; HttpOnly; SameSite=Lax")));
     }
 
     @Test
@@ -431,10 +431,10 @@ public class AuthenticationControllerTest {
         List<String> headers = response.getHeaders("Set-Cookie");
 
         assertThat(headers.size(), is(4));
-        assertThat(headers, hasItem("com.auth0.state=state; HttpOnly; Max-Age=600; SameSite=None; Secure"));
-        assertThat(headers, hasItem("_com.auth0.state=state; HttpOnly; Max-Age=600"));
-        assertThat(headers, hasItem("com.auth0.nonce=nonce; HttpOnly; Max-Age=600; SameSite=None; Secure"));
-        assertThat(headers, hasItem("_com.auth0.nonce=nonce; HttpOnly; Max-Age=600"));
+        assertThat(headers, hasItem(matchesPattern("com.auth0.state=state; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
+        assertThat(headers, hasItem(matchesPattern("_com.auth0.state=state; Max-Age=600; Expires=.*?; HttpOnly")));
+        assertThat(headers, hasItem(matchesPattern("com.auth0.nonce=nonce; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
+        assertThat(headers, hasItem(matchesPattern("_com.auth0.nonce=nonce; Max-Age=600; Expires=.*?; HttpOnly")));
     }
 
     @Test
@@ -454,8 +454,8 @@ public class AuthenticationControllerTest {
         List<String> headers = response.getHeaders("Set-Cookie");
 
         assertThat(headers.size(), is(2));
-        assertThat(headers, hasItem("com.auth0.state=state; HttpOnly; Max-Age=600; SameSite=None; Secure"));
-        assertThat(headers, hasItem("com.auth0.nonce=nonce; HttpOnly; Max-Age=600; SameSite=None; Secure"));
+        assertThat(headers, hasItem(matchesPattern("com.auth0.state=state; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
+        assertThat(headers, hasItem(matchesPattern("com.auth0.nonce=nonce; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
     }
 
     @Test
@@ -581,6 +581,6 @@ public class AuthenticationControllerTest {
         List<String> headers = response.getHeaders("Set-Cookie");
 
         assertThat(headers.size(), is(1));
-        assertThat(headers, everyItem(is("com.auth0.state=state; HttpOnly; Max-Age=600; Path=/Path; SameSite=Lax")));
+        assertThat(headers, everyItem(matchesPattern("com.auth0.state=state; Path=/Path; Max-Age=600; Expires=.*?; HttpOnly; SameSite=Lax")));
     }
 }

--- a/src/test/java/com/auth0/AuthorizeUrlTest.java
+++ b/src/test/java/com/auth0/AuthorizeUrlTest.java
@@ -92,8 +92,8 @@ public class AuthorizeUrlTest {
 
         Collection<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
-        assertThat(headers, hasItem(matchesPattern("com.auth0.nonce=asdfghjkl; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
-        assertThat(headers, hasItem(matchesPattern("_com.auth0.nonce=asdfghjkl; Max-Age=600; Expires=.*?; HttpOnly")));
+        assertThat(headers, hasItem(matchesPattern("com\\.auth0\\.nonce=asdfghjkl; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
+        assertThat(headers, hasItem(matchesPattern("_com\\.auth0\\.nonce=asdfghjkl; Max-Age=600; Expires=.*?; HttpOnly")));
     }
 
     @Test
@@ -106,7 +106,7 @@ public class AuthorizeUrlTest {
 
         Collection<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));
-        assertThat(headers, hasItem(matchesPattern("com.auth0.nonce=asdfghjkl; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
+        assertThat(headers, hasItem(matchesPattern("com\\.auth0\\.nonce=asdfghjkl; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
     }
 
     @Test
@@ -118,8 +118,8 @@ public class AuthorizeUrlTest {
 
         Collection<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
-        assertThat(headers, hasItem(matchesPattern("com.auth0.state=asdfghjkl; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
-        assertThat(headers, hasItem(matchesPattern("_com.auth0.state=asdfghjkl; Max-Age=600; Expires=.*?; HttpOnly")));
+        assertThat(headers, hasItem(matchesPattern("com\\.auth0\\.state=asdfghjkl; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
+        assertThat(headers, hasItem(matchesPattern("_com\\.auth0\\.state=asdfghjkl; Max-Age=600; Expires=.*?; HttpOnly")));
     }
 
     @Test
@@ -132,7 +132,7 @@ public class AuthorizeUrlTest {
 
         Collection<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));
-        assertThat(headers, hasItem(matchesPattern("com.auth0.state=asdfghjkl; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
+        assertThat(headers, hasItem(matchesPattern("com\\.auth0\\.state=asdfghjkl; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
     }
 
     @Test
@@ -145,7 +145,7 @@ public class AuthorizeUrlTest {
 
         Collection<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));
-        assertThat(headers, hasItem(matchesPattern("com.auth0.state=asdfghjkl; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=Lax")));
+        assertThat(headers, hasItem(matchesPattern("com\\.auth0\\.state=asdfghjkl; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=Lax")));
     }
 
     @Test
@@ -158,8 +158,8 @@ public class AuthorizeUrlTest {
 
         Collection<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
-        assertThat(headers, hasItem(matchesPattern("com.auth0.state=asdfghjkl; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
-        assertThat(headers, hasItem(matchesPattern("_com.auth0.state=asdfghjkl; Max-Age=600; Expires=.*?; HttpOnly")));
+        assertThat(headers, hasItem(matchesPattern("com\\.auth0\\.state=asdfghjkl; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
+        assertThat(headers, hasItem(matchesPattern("_com\\.auth0\\.state=asdfghjkl; Max-Age=600; Expires=.*?; HttpOnly")));
     }
 
     @Test

--- a/src/test/java/com/auth0/AuthorizeUrlTest.java
+++ b/src/test/java/com/auth0/AuthorizeUrlTest.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Collection;
 import java.util.Map;
 

--- a/src/test/java/com/auth0/AuthorizeUrlTest.java
+++ b/src/test/java/com/auth0/AuthorizeUrlTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
@@ -91,8 +92,8 @@ public class AuthorizeUrlTest {
 
         Collection<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
-        assertThat(headers, hasItem("com.auth0.nonce=asdfghjkl; HttpOnly; Max-Age=600; SameSite=None; Secure"));
-        assertThat(headers, hasItem("_com.auth0.nonce=asdfghjkl; HttpOnly; Max-Age=600"));
+        assertThat(headers, hasItem(matchesPattern("com.auth0.nonce=asdfghjkl; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
+        assertThat(headers, hasItem(matchesPattern("_com.auth0.nonce=asdfghjkl; Max-Age=600; Expires=.*?; HttpOnly")));
     }
 
     @Test
@@ -105,7 +106,7 @@ public class AuthorizeUrlTest {
 
         Collection<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));
-        assertThat(headers, hasItem("com.auth0.nonce=asdfghjkl; HttpOnly; Max-Age=600; SameSite=None; Secure"));
+        assertThat(headers, hasItem(matchesPattern("com.auth0.nonce=asdfghjkl; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
     }
 
     @Test
@@ -117,8 +118,8 @@ public class AuthorizeUrlTest {
 
         Collection<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
-        assertThat(headers, hasItem("com.auth0.state=asdfghjkl; HttpOnly; Max-Age=600; SameSite=None; Secure"));
-        assertThat(headers, hasItem("_com.auth0.state=asdfghjkl; HttpOnly; Max-Age=600"));
+        assertThat(headers, hasItem(matchesPattern("com.auth0.state=asdfghjkl; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
+        assertThat(headers, hasItem(matchesPattern("_com.auth0.state=asdfghjkl; Max-Age=600; Expires=.*?; HttpOnly")));
     }
 
     @Test
@@ -131,7 +132,7 @@ public class AuthorizeUrlTest {
 
         Collection<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));
-        assertThat(headers, hasItem("com.auth0.state=asdfghjkl; HttpOnly; Max-Age=600; SameSite=None; Secure"));
+        assertThat(headers, hasItem(matchesPattern("com.auth0.state=asdfghjkl; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
     }
 
     @Test
@@ -144,7 +145,7 @@ public class AuthorizeUrlTest {
 
         Collection<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));
-        assertThat(headers, hasItem("com.auth0.state=asdfghjkl; HttpOnly; Max-Age=600; SameSite=Lax; Secure"));
+        assertThat(headers, hasItem(matchesPattern("com.auth0.state=asdfghjkl; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=Lax")));
     }
 
     @Test
@@ -157,8 +158,8 @@ public class AuthorizeUrlTest {
 
         Collection<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
-        assertThat(headers, hasItem("com.auth0.state=asdfghjkl; HttpOnly; Max-Age=600; SameSite=None; Secure"));
-        assertThat(headers, hasItem("_com.auth0.state=asdfghjkl; HttpOnly; Max-Age=600"));
+        assertThat(headers, hasItem(matchesPattern("com.auth0.state=asdfghjkl; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
+        assertThat(headers, hasItem(matchesPattern("_com.auth0.state=asdfghjkl; Max-Age=600; Expires=.*?; HttpOnly")));
     }
 
     @Test

--- a/src/test/java/com/auth0/RequestProcessorTest.java
+++ b/src/test/java/com/auth0/RequestProcessorTest.java
@@ -12,8 +12,8 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/com/auth0/TransientCookieStoreTest.java
+++ b/src/test/java/com/auth0/TransientCookieStoreTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
 
 public class TransientCookieStoreTest {
 
@@ -49,11 +50,9 @@ public class TransientCookieStoreTest {
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
 
-        String expectedEncodedState = URLEncoder.encode(stateVal, "UTF-8");
-        assertThat(headers, hasItem(
-                String.format("com.auth0.state=%s; HttpOnly; Max-Age=600; SameSite=None; Secure", expectedEncodedState)));
-        assertThat(headers, hasItem(
-                String.format("_com.auth0.state=%s; HttpOnly; Max-Age=600", expectedEncodedState)));
+        String expectedEncodedState = URLEncoder.encode(stateVal, "UTF-8").replaceAll("\\+", "\\\\+");
+        assertThat(headers, hasItem(matchesPattern(String.format("com\\.auth0\\.state=%s; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None", expectedEncodedState))));
+        assertThat(headers, hasItem(matchesPattern(String.format("_com\\.auth0\\.state=%s; Max-Age=600; Expires=.*?; HttpOnly", expectedEncodedState))));
     }
 
     @Test
@@ -63,8 +62,8 @@ public class TransientCookieStoreTest {
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
 
-        assertThat(headers, hasItem("com.auth0.state=123456; HttpOnly; Max-Age=600; SameSite=None; Secure"));
-        assertThat(headers, hasItem("_com.auth0.state=123456; HttpOnly; Max-Age=600"));
+        assertThat(headers, hasItem(matchesPattern("com\\.auth0\\.state=123456; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
+        assertThat(headers, hasItem(matchesPattern("_com\\.auth0\\.state=123456; Max-Age=600; Expires=.*?; HttpOnly")));
     }
 
     @Test
@@ -74,7 +73,7 @@ public class TransientCookieStoreTest {
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));
 
-        assertThat(headers, hasItem("com.auth0.state=123456; HttpOnly; Max-Age=600; SameSite=None; Secure"));
+        assertThat(headers, hasItem(matchesPattern("com\\.auth0\\.state=123456; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
     }
 
     @Test
@@ -84,7 +83,7 @@ public class TransientCookieStoreTest {
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));
 
-        assertThat(headers, hasItem("com.auth0.state=123456; HttpOnly; Max-Age=600; SameSite=Lax; Secure"));
+        assertThat(headers, hasItem(matchesPattern("com\\.auth0\\.state=123456; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=Lax")));
     }
 
     @Test
@@ -94,8 +93,8 @@ public class TransientCookieStoreTest {
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
 
-        assertThat(headers, hasItem("com.auth0.state=123456; HttpOnly; Max-Age=600; SameSite=None; Secure"));
-        assertThat(headers, hasItem("_com.auth0.state=123456; HttpOnly; Max-Age=600; Secure"));
+        assertThat(headers, hasItem(matchesPattern("com\\.auth0\\.state=123456; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
+        assertThat(headers, hasItem(matchesPattern("_com\\.auth0\\.state=123456; Max-Age=600; Expires=.*?; Secure; HttpOnly")));
     }
 
     @Test
@@ -105,7 +104,7 @@ public class TransientCookieStoreTest {
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));
 
-        assertThat(headers, hasItem("com.auth0.state=123456; HttpOnly; Max-Age=600; SameSite=Lax"));
+        assertThat(headers, hasItem(matchesPattern("com\\.auth0\\.state=123456; Max-Age=600; Expires=.*?; HttpOnly; SameSite=Lax")));
     }
 
     @Test
@@ -115,8 +114,8 @@ public class TransientCookieStoreTest {
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(2));
 
-        assertThat(headers, hasItem("com.auth0.nonce=123456; HttpOnly; Max-Age=600; SameSite=None; Secure"));
-        assertThat(headers, hasItem("_com.auth0.nonce=123456; HttpOnly; Max-Age=600"));
+        assertThat(headers, hasItem(matchesPattern("com\\.auth0\\.nonce=123456; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
+        assertThat(headers, hasItem(matchesPattern("_com\\.auth0\\.nonce=123456; Max-Age=600; Expires=.*?; HttpOnly")));
     }
 
     @Test
@@ -126,7 +125,7 @@ public class TransientCookieStoreTest {
         List<String> headers = response.getHeaders("Set-Cookie");
         assertThat(headers.size(), is(1));
 
-        assertThat(headers, hasItem("com.auth0.nonce=123456; HttpOnly; Max-Age=600; SameSite=None; Secure"));
+        assertThat(headers, hasItem(matchesPattern("com\\.auth0\\.nonce=123456; Max-Age=600; Expires=.*?; Secure; HttpOnly; SameSite=None")));
     }
 
     @Test

--- a/src/test/java/com/auth0/TransientCookieStoreTest.java
+++ b/src/test/java/com/auth0/TransientCookieStoreTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-import javax.servlet.http.Cookie;
+import jakarta.servlet.http.Cookie;
 import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
### Changes

This is a refactor that upgrades the mvc-common library to Jakarta EE6.0 and JDK 17, allowing use on more modern servers and libraries - the tests were also fixed to account for the expiration of tokens. The main changes were to the build and namespaces of imports - with some changes to the tests using regexes.

### References

solves #111 

### Testing

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of Java or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors

### Added Context

This will break the current API as it changes all the required args to another package. Will fail CI check for API Changes  - but this is expected and part of the issue.