### PR TITLE
[SDK-4670] Improved state handling errors

### DIFF
--- a/src/main/java/com/auth0/RandomStorage.java
+++ b/src/main/java/com/auth0/RandomStorage.java
@@ -15,11 +15,7 @@ class RandomStorage extends SessionUtils {
      */
     static boolean checkSessionState(HttpServletRequest req, String state) {
         String currentState = (String) remove(req, StorageUtils.STATE_KEY);
-        if (currentState == null) {
-            return state == null;
-        } else {
-            return currentState.equals(state);
-        }
+        return (currentState == null && state == null) || currentState != null && currentState.equals(state);
     }
 
     /**

--- a/src/main/java/com/auth0/RandomStorage.java
+++ b/src/main/java/com/auth0/RandomStorage.java
@@ -15,7 +15,11 @@ class RandomStorage extends SessionUtils {
      */
     static boolean checkSessionState(HttpServletRequest req, String state) {
         String currentState = (String) remove(req, StorageUtils.STATE_KEY);
-        return (currentState == null && state == null) || currentState != null && currentState.equals(state);
+        if (currentState == null && state == null) {
+            return true;
+        } else {
+            return (currentState != null && currentState.equals(state));
+        }
     }
 
     /**

--- a/src/main/java/com/auth0/RandomStorage.java
+++ b/src/main/java/com/auth0/RandomStorage.java
@@ -15,10 +15,10 @@ class RandomStorage extends SessionUtils {
      */
     static boolean checkSessionState(HttpServletRequest req, String state) {
         String currentState = (String) remove(req, StorageUtils.STATE_KEY);
-        if (currentState == null && state == null) {
-            return true;
+        if (currentState == null) {
+            return state == null;
         } else {
-            return (currentState != null && currentState.equals(state));
+            return currentState.equals(state);
         }
     }
 

--- a/src/test/java/com/auth0/RandomStorageTest.java
+++ b/src/test/java/com/auth0/RandomStorageTest.java
@@ -25,6 +25,13 @@ public class RandomStorageTest {
     }
 
     @Test
+    public void shouldFailIfSessionStateIsNullButCurrentStateNotNull() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        boolean validState = RandomStorage.checkSessionState(req, "12345");
+        assertThat(validState, is(false));
+    }
+
+    @Test
     public void shouldCheckAndRemoveInvalidState() {
         MockHttpServletRequest req = new MockHttpServletRequest();
         req.getSession().setAttribute("com.auth0.state", "123456");


### PR DESCRIPTION
### Changes

This PR provides additional information to the error message received when a state validation error occurs. To minimize any potential breaking changes, it:

* Does not introduce any new exception classes
* Does not modify the existing exception messaging (in case clients pattern match on the message), but does add additional messaging to indicate the source of the error (missing auth state param, missing state value, or state mismatch between session/cookie value and auth response param)

Note that the SDK currently needs to support the deprecated methods that use the session for auth state param storage (both for building the auth URL as well as processing the callback). In v2, we should:

* Remove deprecated methods that store auth params in the session
* Provide specific exception types for various state validation errors (e.g., state param missing from the auth response, state cookie not present, or state value mismatch), as well as provided specific and improved exception messages. See the [nextjs-auth0 SDK](https://github.com/auth0/nextjs-auth0/blob/4cecaa6085aba65c1966817d86c5bdc9a4bb9d2e/src/auth0-session/utils/errors.ts#L13) for an example.

Note that this change also includes additional tests for functionality that was _not_ changed, in addition to tests for the changes. The [first commit](https://github.com/auth0/auth0-java-mvc-common/commit/4cf235c40de35aa31ee2f70527884b92badb4d3b
) adds tests to cover all paths prior to the change, as well as updates tests to the new expected behavor. [This commit](https://github.com/auth0/auth0-java-mvc-common/commit/603f619b4e56085a02f60cceee204b46db7b1eba) provides the functional change.