### PR TITLE
chore: Update CI/CD workflows for v2

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,9 +2,10 @@ name: auth0/auth0-java-mvc-common/build-and-test
 
 on:
   pull_request:
+    branches: ["master", "v2"]
   merge_group:
   push:
-    branches: ["master", "v1", "v2"]
+    branches: ["master"]
 
 jobs:
   gradle:
@@ -14,7 +15,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: ${{ (github.ref == 'refs/heads/v1' || github.base_ref == 'v1') && '8' || '17' }}
+          java-version: 17
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master", "v1", "v2"]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "master", "v1" ]
+    branches: [ "master", "v2" ]
   schedule:
     - cron: "30 19 * * 6"
 
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: ${{ (github.ref == 'refs/heads/v1' || github.base_ref == 'v1') && '8' || '17' }}
+          java-version: 17
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   rl-scanner:
     uses: ./.github/workflows/rl-secure.yml
     with:
-      java-version: ${{ (github.ref == 'refs/heads/v1' || github.base_ref == 'v1') && '8' || '17' }}
+      java-version: 17
       artifact-name: "auth0-java-mvc-common.tgz"
     secrets:
       RLSECURE_LICENSE: ${{ secrets.RLSECURE_LICENSE }}
@@ -32,7 +32,7 @@ jobs:
     uses: ./.github/workflows/java-release.yml
     needs: rl-scanner
     with:
-      java-version: ${{ (github.ref == 'refs/heads/v1' || github.base_ref == 'v1') && '8' || '17' }}
+      java-version: 17
     secrets:
       ossr-username: ${{ secrets.OSSR_USERNAME }}
       ossr-token: ${{ secrets.OSSR_TOKEN }}

--- a/.github/workflows/sca_scan.yml
+++ b/.github/workflows/sca_scan.yml
@@ -2,14 +2,14 @@ name: SCA
 
 on:
   push:
-    branches: ["master", "v1", "v2"]
+    branches: ["master"]
   pull_request:
-    branches: ["master", "v1", "v2"]
+    branches: ["master", "v2"]
 
 jobs:
   snyk-cli:
     uses: auth0/devsecops-tooling/.github/workflows/sca-scan.yml@main
     with:
       additional-arguments: "--exclude=README.md"
-      java-version: ${{ (github.ref == 'refs/heads/v1' || github.base_ref == 'v1') && '8' || '17' }}
+      java-version: "17"
     secrets: inherit


### PR DESCRIPTION
### Changes 

Simplify GitHub workflows for the v2 branch, Java 17, and fix duplicate workflow runs.                                                                            
  