### PR TITLE
Feat: Add withHttpClient support

### DIFF
--- a/src/main/java/com/auth0/AuthenticationController.java
+++ b/src/main/java/com/auth0/AuthenticationController.java
@@ -1,6 +1,7 @@
 package com.auth0;
 
 import com.auth0.jwk.JwkProvider;
+import com.auth0.net.client.Auth0HttpClient;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.Validate;
 
@@ -73,6 +74,7 @@ public class AuthenticationController {
         private final String clientSecret;
         private String responseType;
         private JwkProvider jwkProvider;
+        private Auth0HttpClient httpClient;
         private Integer clockSkew;
         private Integer authenticationMaxAge;
         private boolean useLegacySameSiteCookie;
@@ -180,6 +182,31 @@ public class AuthenticationController {
         }
 
         /**
+         * Sets a custom {@link Auth0HttpClient} to use for all HTTP requests made by this library
+         * (token exchange, PAR, etc.). Use this to configure timeouts, proxies, or other HTTP settings.
+         *
+         * <pre>{@code
+         * Auth0HttpClient httpClient = DefaultHttpClient.newBuilder()
+         *     .withConnectTimeout(10)
+         *     .withReadTimeout(10)
+         *     .build();
+         *
+         * AuthenticationController controller = AuthenticationController
+         *     .newBuilder(domain, clientId, clientSecret)
+         *     .withHttpClient(httpClient)
+         *     .build();
+         * }</pre>
+         *
+         * @param httpClient a configured {@link Auth0HttpClient} instance.
+         * @return this same builder instance.
+         */
+        public Builder withHttpClient(Auth0HttpClient httpClient) {
+            Validate.notNull(httpClient);
+            this.httpClient = httpClient;
+            return this;
+        }
+
+        /**
          * Sets the clock-skew or leeway value to use in the ID Token verification. The value must be in seconds.
          * Defaults to 60 seconds.
          *
@@ -266,6 +293,9 @@ public class AuthenticationController {
 
             if (jwkProvider != null) {
                 builder.withJwkProvider(jwkProvider);
+            }
+            if (httpClient != null) {
+                builder.withHttpClient(httpClient);
             }
 
             return new AuthenticationController(builder.build());

--- a/src/main/java/com/auth0/AuthenticationController.java
+++ b/src/main/java/com/auth0/AuthenticationController.java
@@ -201,7 +201,7 @@ public class AuthenticationController {
          * @return this same builder instance.
          */
         public Builder withHttpClient(Auth0HttpClient httpClient) {
-            Validate.notNull(httpClient);
+            Validate.notNull(httpClient, "httpClient must not be null");
             this.httpClient = httpClient;
             return this;
         }

--- a/src/main/java/com/auth0/AuthenticationController.java
+++ b/src/main/java/com/auth0/AuthenticationController.java
@@ -185,10 +185,18 @@ public class AuthenticationController {
          * Sets a custom {@link Auth0HttpClient} to use for all HTTP requests made by this library
          * (token exchange, PAR, etc.). Use this to configure timeouts, proxies, or other HTTP settings.
          *
+         * <p><strong>Note:</strong> When a custom {@code Auth0HttpClient} is provided, the
+         * {@link AuthenticationController#setLoggingEnabled(boolean)} and
+         * {@link AuthenticationController#doNotSendTelemetry()} settings will have no effect,
+         * as those are configured at the HTTP client level. You should configure logging and
+         * telemetry directly on the client instance before passing it here.</p>
+         *
          * <pre>{@code
          * Auth0HttpClient httpClient = DefaultHttpClient.newBuilder()
          *     .withConnectTimeout(10)
          *     .withReadTimeout(10)
+         *     .telemetryEnabled(false)
+         *     .withLogging(new LoggingOptions(LoggingOptions.LogLevel.BODY))
          *     .build();
          *
          * AuthenticationController controller = AuthenticationController

--- a/src/main/java/com/auth0/RequestProcessor.java
+++ b/src/main/java/com/auth0/RequestProcessor.java
@@ -11,6 +11,7 @@ import com.auth0.jwk.Jwk;
 import com.auth0.jwk.JwkException;
 import com.auth0.jwk.JwkProvider;
 import com.auth0.jwk.UrlJwkProvider;
+import com.auth0.net.client.Auth0HttpClient;
 import com.auth0.net.client.DefaultHttpClient;
 import com.auth0.utils.tokens.IdTokenVerifier;
 import com.auth0.utils.tokens.SignatureVerifier;
@@ -50,6 +51,7 @@ class RequestProcessor {
     private final String clientId;
     private final String clientSecret;
     private final JwkProvider jwkProvider;
+    private Auth0HttpClient httpClient;
 
     private final Integer clockSkew;
     private final Integer authenticationMaxAge;
@@ -71,6 +73,7 @@ class RequestProcessor {
         private final String clientSecret;
 
         private JwkProvider jwkProvider;
+        private Auth0HttpClient httpClient;
         private boolean useLegacySameSiteCookie = true;
         private Integer clockSkew;
         private Integer authenticationMaxAge;
@@ -90,6 +93,11 @@ class RequestProcessor {
 
         Builder withJwkProvider(JwkProvider jwkProvider) {
             this.jwkProvider = jwkProvider;
+            return this;
+        }
+
+        Builder withHttpClient(Auth0HttpClient httpClient) {
+            this.httpClient = httpClient;
             return this;
         }
 
@@ -125,13 +133,13 @@ class RequestProcessor {
 
         RequestProcessor build() {
             return new RequestProcessor(domainProvider, responseType, clientId, clientSecret,
-                    jwkProvider, useLegacySameSiteCookie, clockSkew, authenticationMaxAge,
+                    jwkProvider, httpClient, useLegacySameSiteCookie, clockSkew, authenticationMaxAge,
                     organization, invitation, cookiePath);
         }
     }
 
     private RequestProcessor(DomainProvider domainProvider, String responseType, String clientId,
-            String clientSecret, JwkProvider jwkProvider,
+            String clientSecret, JwkProvider jwkProvider, Auth0HttpClient httpClient,
             boolean useLegacySameSiteCookie, Integer clockSkew, Integer authenticationMaxAge,
             String organization, String invitation, String cookiePath) {
         this.domainProvider = domainProvider;
@@ -139,6 +147,7 @@ class RequestProcessor {
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.jwkProvider = jwkProvider;
+        this.httpClient = httpClient;
         this.useLegacySameSiteCookie = useLegacySameSiteCookie;
         this.clockSkew = clockSkew;
         this.authenticationMaxAge = authenticationMaxAge;
@@ -156,16 +165,21 @@ class RequestProcessor {
     }
 
     AuthAPI createClientForDomain(String domain) {
-        DefaultHttpClient.Builder httpBuilder = DefaultHttpClient.newBuilder()
-                .telemetryEnabled(!telemetryDisabled);
-
-        if (loggingEnabled) {
-            httpBuilder.withLogging(new LoggingOptions(LoggingOptions.LogLevel.BODY));
-        }
-
         return AuthAPI.newBuilder(domain, clientId, clientSecret)
-                .withHttpClient(httpBuilder.build())
+                .withHttpClient(getHttpClient())
                 .build();
+    }
+
+    private Auth0HttpClient getHttpClient() {
+        if (this.httpClient == null) {
+            DefaultHttpClient.Builder httpBuilder = DefaultHttpClient.newBuilder()
+                    .telemetryEnabled(!telemetryDisabled);
+            if (loggingEnabled) {
+                httpBuilder.withLogging(new LoggingOptions(LoggingOptions.LogLevel.BODY));
+            }
+            this.httpClient = httpBuilder.build();
+        }
+        return this.httpClient;
     }
 
     /**

--- a/src/test/java/com/auth0/AuthenticationControllerTest.java
+++ b/src/test/java/com/auth0/AuthenticationControllerTest.java
@@ -1,6 +1,7 @@
 package com.auth0;
 
 import com.auth0.jwk.JwkProvider;
+import com.auth0.net.client.Auth0HttpClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -30,6 +31,8 @@ public class AuthenticationControllerTest {
     private JwkProvider mockJwkProvider;
     @Mock
     private DomainResolver mockDomainResolver;
+    @Mock
+    private Auth0HttpClient mockHttpClient;
     @Mock
     private Tokens mockTokens;
 
@@ -82,6 +85,7 @@ public class AuthenticationControllerTest {
         AuthenticationController controller = AuthenticationController.newBuilder(DOMAIN, CLIENT_ID, CLIENT_SECRET)
                 .withResponseType("id_token token")
                 .withJwkProvider(mockJwkProvider)
+                .withHttpClient(mockHttpClient)
                 .withClockSkew(120)
                 .withAuthenticationMaxAge(3600)
                 .withLegacySameSiteCookie(false)
@@ -131,6 +135,7 @@ public class AuthenticationControllerTest {
         assertThrows(NullPointerException.class, () -> builder.withDomain(null));
         assertThrows(NullPointerException.class, () -> builder.withResponseType(null));
         assertThrows(NullPointerException.class, () -> builder.withJwkProvider(null));
+        assertThrows(NullPointerException.class, () -> builder.withHttpClient(null));
         assertThrows(NullPointerException.class, () -> builder.withClockSkew(null));
         assertThrows(NullPointerException.class, () -> builder.withAuthenticationMaxAge(null));
         assertThrows(NullPointerException.class, () -> builder.withOrganization(null));
@@ -420,5 +425,44 @@ public class AuthenticationControllerTest {
                 .build();
 
         assertThat(controller, is(notNullValue()));
+    }
+
+    // --- HttpClient Configuration Tests ---
+
+    @Test
+    public void shouldBuildWithCustomHttpClient() {
+        AuthenticationController controller = AuthenticationController.newBuilder(DOMAIN, CLIENT_ID, CLIENT_SECRET)
+                .withHttpClient(mockHttpClient)
+                .build();
+
+        assertThat(controller, is(notNullValue()));
+        assertThat(controller.getRequestProcessor(), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldBuildWithCustomHttpClientAndJwkProvider() {
+        AuthenticationController controller = AuthenticationController.newBuilder(DOMAIN, CLIENT_ID, CLIENT_SECRET)
+                .withHttpClient(mockHttpClient)
+                .withJwkProvider(mockJwkProvider)
+                .build();
+
+        assertThat(controller, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldBuildWithCustomHttpClientAndDomainResolver() {
+        AuthenticationController controller = AuthenticationController
+                .newBuilder(mockDomainResolver, CLIENT_ID, CLIENT_SECRET)
+                .withHttpClient(mockHttpClient)
+                .build();
+
+        assertThat(controller, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenHttpClientIsNull() {
+        AuthenticationController.Builder builder = AuthenticationController.newBuilder(DOMAIN, CLIENT_ID, CLIENT_SECRET);
+
+        assertThrows(NullPointerException.class, () -> builder.withHttpClient(null));
     }
 }

--- a/src/test/java/com/auth0/RequestProcessorTest.java
+++ b/src/test/java/com/auth0/RequestProcessorTest.java
@@ -6,6 +6,7 @@ import com.auth0.json.auth.TokenHolder;
 import com.auth0.jwk.JwkProvider;
 import com.auth0.net.Response;
 import com.auth0.net.TokenRequest;
+import com.auth0.net.client.Auth0HttpClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -43,6 +44,8 @@ public class RequestProcessorTest {
     private DomainProvider mockDomainProvider;
     @Mock
     private JwkProvider mockJwkProvider;
+    @Mock
+    private Auth0HttpClient mockHttpClient;
     @Mock
     private AuthAPI mockAuthAPI;
     @Mock
@@ -644,6 +647,264 @@ public class RequestProcessorTest {
                 .build();
 
         assertThat(processor, is(notNullValue()));
+    }
+
+    // --- Custom HttpClient Tests ---
+
+    @Test
+    public void shouldBuildWithCustomHttpClient() {
+        RequestProcessor processor = new RequestProcessor.Builder(
+                mockDomainProvider,
+                RESPONSE_TYPE_CODE,
+                CLIENT_ID,
+                CLIENT_SECRET)
+                .withHttpClient(mockHttpClient)
+                .build();
+
+        assertThat(processor, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldCreateClientForDomainWithCustomHttpClient() {
+        RequestProcessor processor = new RequestProcessor.Builder(
+                mockDomainProvider,
+                RESPONSE_TYPE_CODE,
+                CLIENT_ID,
+                CLIENT_SECRET)
+                .withHttpClient(mockHttpClient)
+                .build();
+
+        AuthAPI client = processor.createClientForDomain(DOMAIN);
+        assertThat(client, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldReuseCustomHttpClientAcrossMultipleDomains() {
+        RequestProcessor processor = new RequestProcessor.Builder(
+                mockDomainProvider,
+                RESPONSE_TYPE_CODE,
+                CLIENT_ID,
+                CLIENT_SECRET)
+                .withHttpClient(mockHttpClient)
+                .build();
+
+        AuthAPI client1 = processor.createClientForDomain("domain1.auth0.com");
+        AuthAPI client2 = processor.createClientForDomain("domain2.auth0.com");
+
+        assertThat(client1, is(notNullValue()));
+        assertThat(client2, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldCreateDefaultHttpClientWhenNoneProvided() {
+        RequestProcessor processor = new RequestProcessor.Builder(
+                mockDomainProvider,
+                RESPONSE_TYPE_CODE,
+                CLIENT_ID,
+                CLIENT_SECRET)
+                .build();
+
+        AuthAPI client = processor.createClientForDomain(DOMAIN);
+        assertThat(client, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldReuseDefaultHttpClientAcrossMultipleCalls() {
+        RequestProcessor processor = new RequestProcessor.Builder(
+                mockDomainProvider,
+                RESPONSE_TYPE_CODE,
+                CLIENT_ID,
+                CLIENT_SECRET)
+                .build();
+
+        AuthAPI client1 = processor.createClientForDomain("domain1.auth0.com");
+        AuthAPI client2 = processor.createClientForDomain("domain2.auth0.com");
+
+        assertThat(client1, is(notNullValue()));
+        assertThat(client2, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldBuildWithHttpClientAndJwkProvider() {
+        RequestProcessor processor = new RequestProcessor.Builder(
+                mockDomainProvider,
+                RESPONSE_TYPE_CODE,
+                CLIENT_ID,
+                CLIENT_SECRET)
+                .withHttpClient(mockHttpClient)
+                .withJwkProvider(mockJwkProvider)
+                .build();
+
+        assertThat(processor, is(notNullValue()));
+    }
+
+    // --- Transaction-Keyed Cookie Tests ---
+
+    @Test
+    public void shouldValidateStateFromTransactionKeyedCookie() {
+        when(mockDomainProvider.getDomain(any())).thenReturn(DOMAIN);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("state", "txn-state-123");
+        params.put("code", "auth-code");
+        MockHttpServletRequest request = getRequest(params);
+        // Transaction-keyed cookie: com.auth0.state.{state_value}
+        request.setCookies(new Cookie("com.auth0.state.txn-state-123", "txn-state-123"));
+
+        when(mockTokenHolder.getIdToken()).thenReturn(null);
+        when(mockTokenHolder.getAccessToken()).thenReturn("access");
+        when(mockTokenResponse.getBody()).thenReturn(mockTokenHolder);
+        try {
+            when(mockTokenRequest.execute()).thenReturn(mockTokenResponse);
+        } catch (Auth0Exception e) {
+            fail("Unexpected exception");
+        }
+        when(mockAuthAPI.exchangeCode(eq("auth-code"), anyString())).thenReturn(mockTokenRequest);
+
+        RequestProcessor handler = createDefaultRequestProcessor();
+        RequestProcessor spy = spy(handler);
+        doReturn(mockAuthAPI).when(spy).createClientForDomain(anyString());
+
+        assertDoesNotThrow(() -> spy.process(request, response));
+    }
+
+    @Test
+    public void shouldFallbackToLegacyStateCookieWhenTransactionKeyedMissing() {
+        when(mockDomainProvider.getDomain(any())).thenReturn(DOMAIN);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("state", "legacy-state-456");
+        params.put("code", "auth-code");
+        MockHttpServletRequest request = getRequest(params);
+        // Legacy fixed-name cookie (v1 compatibility)
+        request.setCookies(new Cookie("com.auth0.state", "legacy-state-456"));
+
+        when(mockTokenHolder.getIdToken()).thenReturn(null);
+        when(mockTokenHolder.getAccessToken()).thenReturn("access");
+        when(mockTokenResponse.getBody()).thenReturn(mockTokenHolder);
+        try {
+            when(mockTokenRequest.execute()).thenReturn(mockTokenResponse);
+        } catch (Auth0Exception e) {
+            fail("Unexpected exception");
+        }
+        when(mockAuthAPI.exchangeCode(eq("auth-code"), anyString())).thenReturn(mockTokenRequest);
+
+        RequestProcessor handler = createDefaultRequestProcessor();
+        RequestProcessor spy = spy(handler);
+        doReturn(mockAuthAPI).when(spy).createClientForDomain(anyString());
+
+        assertDoesNotThrow(() -> spy.process(request, response));
+    }
+
+    @Test
+    public void shouldRejectWhenNoStateCookieExists() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("state", "orphan-state");
+        MockHttpServletRequest request = getRequest(params);
+        // No cookies at all
+
+        RequestProcessor handler = createDefaultRequestProcessor();
+
+        InvalidRequestException e = assertThrows(InvalidRequestException.class, () -> handler.process(request, response));
+        assertThat(e.getCode(), is("a0.invalid_state"));
+    }
+
+    // --- MCD Origin Domain Binding Tests ---
+
+    @Test
+    public void shouldUseDomainFromSignedCookieWhenPresent() throws Exception {
+        String state = "mcd-state-789";
+        String domain = "brand-a.auth0.com";
+
+        // Create a signed origin domain cookie
+        String signedDomain = SignedCookieUtils.sign(domain, state, CLIENT_SECRET);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("state", state);
+        params.put("code", "auth-code");
+        MockHttpServletRequest request = getRequest(params);
+        request.setCookies(
+                new Cookie("com.auth0.state." + state, state),
+                new Cookie("com.auth0.origin_domain", signedDomain)
+        );
+
+        when(mockDomainProvider.getDomain(any())).thenReturn("fallback.auth0.com");
+        when(mockTokenHolder.getIdToken()).thenReturn(null);
+        when(mockTokenHolder.getAccessToken()).thenReturn("access");
+        when(mockTokenResponse.getBody()).thenReturn(mockTokenHolder);
+        when(mockTokenRequest.execute()).thenReturn(mockTokenResponse);
+        when(mockAuthAPI.exchangeCode(eq("auth-code"), anyString())).thenReturn(mockTokenRequest);
+
+        RequestProcessor handler = createDefaultRequestProcessor();
+        RequestProcessor spy = spy(handler);
+        doReturn(mockAuthAPI).when(spy).createClientForDomain(anyString());
+
+        spy.process(request, response);
+
+        // Should use the domain from the signed cookie, not the fallback
+        verify(spy).createClientForDomain(domain);
+    }
+
+    @Test
+    public void shouldFallbackToDomainProviderWhenSignedCookieMissing() throws Exception {
+        String state = "no-cookie-state";
+        String fallbackDomain = "fallback.auth0.com";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("state", state);
+        params.put("code", "auth-code");
+        MockHttpServletRequest request = getRequest(params);
+        request.setCookies(new Cookie("com.auth0.state." + state, state));
+
+        when(mockDomainProvider.getDomain(any())).thenReturn(fallbackDomain);
+        when(mockTokenHolder.getIdToken()).thenReturn(null);
+        when(mockTokenHolder.getAccessToken()).thenReturn("access");
+        when(mockTokenResponse.getBody()).thenReturn(mockTokenHolder);
+        when(mockTokenRequest.execute()).thenReturn(mockTokenResponse);
+        when(mockAuthAPI.exchangeCode(eq("auth-code"), anyString())).thenReturn(mockTokenRequest);
+
+        RequestProcessor handler = createDefaultRequestProcessor();
+        RequestProcessor spy = spy(handler);
+        doReturn(mockAuthAPI).when(spy).createClientForDomain(anyString());
+
+        spy.process(request, response);
+
+        // Should fall back to domainProvider when no signed origin cookie
+        verify(spy).createClientForDomain(fallbackDomain);
+    }
+
+    @Test
+    public void shouldFallbackToDomainProviderWhenSignedCookieTampered() throws Exception {
+        String state = "tampered-state";
+        String fallbackDomain = "fallback.auth0.com";
+
+        // Tampered cookie — signed with different state
+        String signedDomain = SignedCookieUtils.sign("evil.auth0.com", "different-state", CLIENT_SECRET);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("state", state);
+        params.put("code", "auth-code");
+        MockHttpServletRequest request = getRequest(params);
+        request.setCookies(
+                new Cookie("com.auth0.state." + state, state),
+                new Cookie("com.auth0.origin_domain", signedDomain)
+        );
+
+        when(mockDomainProvider.getDomain(any())).thenReturn(fallbackDomain);
+        when(mockTokenHolder.getIdToken()).thenReturn(null);
+        when(mockTokenHolder.getAccessToken()).thenReturn("access");
+        when(mockTokenResponse.getBody()).thenReturn(mockTokenHolder);
+        when(mockTokenRequest.execute()).thenReturn(mockTokenResponse);
+        when(mockAuthAPI.exchangeCode(eq("auth-code"), anyString())).thenReturn(mockTokenRequest);
+
+        RequestProcessor handler = createDefaultRequestProcessor();
+        RequestProcessor spy = spy(handler);
+        doReturn(mockAuthAPI).when(spy).createClientForDomain(anyString());
+
+        spy.process(request, response);
+
+        // Tampered cookie should be rejected, fallback to domainProvider
+        verify(spy).createClientForDomain(fallbackDomain);
     }
 
     // --- Helper Methods ---


### PR DESCRIPTION

## Summary

  - Added `withHttpClient(Auth0HttpClient)` to `AuthenticationController.Builder` as the replacement for the removed `withHttpOptions(HttpOptions)` — allows users to configure timeouts, proxies, and
  custom HTTP behavior
  - The HTTP client instance is lazily created (if not provided) and reused across all MCD domain calls, avoiding per-request connection pool creation
  - Added test coverage for `withHttpClient`, transaction-keyed cookies, MCD origin domain binding (HMAC verification + tamper rejection), and legacy cookie fallback


