### PR TITLE
Release 2.0.0 beta.0

### DIFF
--- a/.github/workflows/rl-secure.yml
+++ b/.github/workflows/rl-secure.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
-      - name: Test and Assemble and ApiDiff with Gradle
-        run: ./gradlew assemble apiDiff check jacocoTestReport --continue --console=plain
+      - name: Test and Assemble with Gradle
+        run: ./gradlew assemble check jacocoTestReport --continue --console=plain
 
       - name: Get Artifact Version
         id: get_version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Change Log
 
+## [2.0.0-beta.0](https://github.com/auth0/auth0-java-mvc-common/tree/2.0.0-beta.0) (2026-05-29)
+
+This is the first beta release of the v2 major version. See the [Migration Guide](MIGRATION_GUIDE.md) for full upgrade instructions.
+
+**Added**
+- Jakarta EE 10 / Jakarta Servlet 6.0 support (replaces `javax.servlet`) [\#154](https://github.com/auth0/auth0-java-mvc-common/pull/154) ([tanya732](https://github.com/tanya732))
+- Transaction-keyed cookies to prevent multi-tab OAuth state race conditions [\#231](https://github.com/auth0/auth0-java-mvc-common/pull/231) ([tanya732](https://github.com/tanya732))
+- `withHttpClient(Auth0HttpClient)` builder method for custom HTTP client configuration [\#234](https://github.com/auth0/auth0-java-mvc-common/pull/234) ([tanya732](https://github.com/tanya732))
+- Algorithm auto-detection from token `alg` header (RS256/HS256) [\#154](https://github.com/auth0/auth0-java-mvc-common/pull/154) ([tanya732](https://github.com/tanya732))
+- ID Token signature is now always verified — no code path allows unverified tokens [\#154](https://github.com/auth0/auth0-java-mvc-common/pull/154) ([tanya732](https://github.com/tanya732))
+- MCD security fix: HMAC-signed origin domain cookies bound to state parameter [\#154](https://github.com/auth0/auth0-java-mvc-common/pull/154) ([tanya732](https://github.com/tanya732))
+- JPMS module support (`com.auth0.mvc.commons`) [\#154](https://github.com/auth0/auth0-java-mvc-common/pull/154) ([tanya732](https://github.com/tanya732))
+- ID Token validation delegated to auth0-java v3's `IdTokenVerifier` [\#154](https://github.com/auth0/auth0-java-mvc-common/pull/154) ([tanya732](https://github.com/tanya732))
+- Migration guide for v1 to v2 upgrade [\#233](https://github.com/auth0/auth0-java-mvc-common/pull/233) ([tanya732](https://github.com/tanya732))
+
+**Changed**
+- Minimum Java version raised from 8 to 17 [\#154](https://github.com/auth0/auth0-java-mvc-common/pull/154) ([tanya732](https://github.com/tanya732))
+- Upgraded auth0-java from v2 to v3.5.1 (`AuthAPI.newBuilder()` pattern) [\#154](https://github.com/auth0/auth0-java-mvc-common/pull/154) ([tanya732](https://github.com/tanya732))
+- Upgraded java-jwt from v3 to v4.5.0 [\#154](https://github.com/auth0/auth0-java-mvc-common/pull/154) ([tanya732](https://github.com/tanya732))
+- Upgraded jwks-rsa to v0.24.1 [\#154](https://github.com/auth0/auth0-java-mvc-common/pull/154) ([tanya732](https://github.com/tanya732))
+
+**Removed**
+- Deprecated `handle(HttpServletRequest)` — use `handle(HttpServletRequest, HttpServletResponse)` instead [\#154](https://github.com/auth0/auth0-java-mvc-common/pull/154) ([tanya732](https://github.com/tanya732))
+- Deprecated `buildAuthorizeUrl(HttpServletRequest, String)` — use `buildAuthorizeUrl(HttpServletRequest, HttpServletResponse, String)` instead [\#154](https://github.com/auth0/auth0-java-mvc-common/pull/154) ([tanya732](https://github.com/tanya732))
+- `withHttpOptions(HttpOptions)` on Builder — use `withHttpClient(Auth0HttpClient)` instead [\#154](https://github.com/auth0/auth0-java-mvc-common/pull/154) ([tanya732](https://github.com/tanya732))
+- `InvalidRequestException.getDescription()` — use `getMessage()` instead [\#154](https://github.cm/auth0/auth0-java-mvc-common/pull/154) ([tanya732](https://github.com/tanya732))
+- Custom signature verifier classes: `IdTokenVerifier`, `SignatureVerifier`, `AsymmetricSignatureVerifier`, `SymmetricSignatureVerifier`, `AlgorithmNameVerifier`, `TokenValidationException` [\#154](https://github.com/auth0/auth0-java-mvc-common/pull/154) ([tanya732](https://github.com/tanya732))
+- Session-based storage classes: `RandomStorage`, `SessionUtils` [\#154](https://github.com/auth0/auth0-java-mvc-common/pull/154) ([tanya732](https://github.com/tanya732))
+
+> **Note:** All deprecated endpoints from v1.x have been removed in this release. Session (HTTP Session) based state/nonce storage has been replaced with secure transient cookies — the library no longer uses `HttpSession` for OAuth state management.
+
+---
+
 ## [1.12.0](https://github.com/auth0/auth0-java-mvc-common/tree/1.12.0) (2026-04-09)
 [Full Changelog](https://github.com/auth0/auth0-java-mvc-common/compare/1.11.1...1.12.0)
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,7 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-
-    dependencies {
-        // https://github.com/melix/japicmp-gradle-plugin/issues/36
-        classpath 'com.google.guava:guava:31.1-jre'
-    }
-}
-
 plugins {
     id 'java'
     id 'java-library'
     id 'jacoco'
-    id 'me.champeau.gradle.japicmp' version '0.4.6'
     id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
@@ -27,61 +15,7 @@ version = getVersionFromFile()
 group = GROUP
 logger.lifecycle("Using version ${version} for ${name} group $group")
 
-import me.champeau.gradle.japicmp.JapicmpTask
-
-//project.afterEvaluate {
-//    def versions = project.ext.testInJavaVersions
-//    for (pluginJavaTestVersion in versions) {
-//        def taskName = "testInJava-${pluginJavaTestVersion}"
-//        tasks.register(taskName, Test) {
-//            def versionToUse = taskName.split("-").getAt(1) as Integer
-//            description = "Runs unit tests on Java version ${versionToUse}."
-//            project.logger.quiet("Test will be running in ${versionToUse}")
-//            group = 'verification'
-//            javaLauncher.set(javaToolchains.launcherFor {
-//                languageVersion = JavaLanguageVersion.of(versionToUse)
-//            })
-//            shouldRunAfter(tasks.named('test'))
-//        }
-//        tasks.named('check') {
-//            dependsOn(taskName)
-//        }
-//    }
-//
-//    project.configure(project) {
-//        def baselineVersion = project.ext.baselineCompareVersion
-//        task('apiDiff', type: JapicmpTask, dependsOn: 'jar') {
-//            oldClasspath.from(files(getBaselineJar(project, baselineVersion)))
-//            newClasspath.from(files(jar.archiveFile))
-//            onlyModified = true
-//            failOnModification = true
-//            ignoreMissingClasses = true
-//            htmlOutputFile = file("$buildDir/reports/apiDiff/apiDiff.html")
-//            txtOutputFile = file("$buildDir/reports/apiDiff/apiDiff.txt")
-//            doLast {
-//                project.logger.quiet("Comparing against baseline version ${baselineVersion}")
-//            }
-//        }
-//    }
-//}
-//
-//private static File getBaselineJar(Project project, String baselineVersion) {
-//    // Use detached configuration: https://github.com/square/okhttp/blob/master/build.gradle#L270
-//    def group = project.group
-//    try {
-//        def baseline = "${project.group}:${project.name}:$baselineVersion"
-//        project.group = 'virtual_group_for_japicmp'
-//        def dependency = project.dependencies.create(baseline + "@jar")
-//        return project.configurations.detachedConfiguration(dependency).files.find {
-//            it.name == "${project.name}-${baselineVersion}.jar"
-//        }
-//    } finally {
-//        project.group = group
-//    }
-//}
-
 ext {
-    baselineCompareVersion = '1.5.0'
     testInJavaVersions = [17, 21]
 }
 


### PR DESCRIPTION
## Summary

  First beta release of `mvc-auth-commons` v2 — a major upgrade migrating from Java 8 / `javax.servlet` to **Java 17 / Jakarta Servlet 6.0**, with security hardening, deprecated API removal, and
  dependency modernization.

  ---

  ## Included PRs
  
  | PR | Description |
  |----|-------------|
  | #152 | Upgrade `auth0-java` to v3 |
  | #155 | Upgrade `java-jwt` to v4.5.0 |
  | #207 | Java 17 + Jakarta migration |
  | #220 | Remove deprecated APIs |
  | #221 | Migrate ID token validation to `auth0-java` v3 |
  | #223 | Add transaction binding security fix |
  | #225 | Add JPMS `module-info.java` support |
  | #231 | Transaction-keyed cookies to prevent multi-tab OAuth state race conditions |
  | #234 | `withHttpClient(Auth0HttpClient)` builder method |

  ---

  ## Key Changes

  ### Platform & Dependency Upgrades

  - `javax.servlet` → `jakarta.servlet` (Jakarta Servlet 6.0)
  - Java 17 minimum requirement
  - Upgraded:
    - `auth0-java` → v3.5.1 (`AuthAPI.newBuilder()` pattern)
    - `java-jwt` → v4.5.0
    - `jwks-rsa` → v0.24.1
    - Gradle 8.x

  ### Security Improvements

  - **HMAC-signed origin domain cookies** bound to OAuth state parameter (MCD hardening)
  - **ID Token signature always verified** — no code path allows unverified tokens
  - **Algorithm auto-detection** from token `alg` header (RS256/HS256)
  - **Transaction-keyed cookies** isolate concurrent login flows (multi-tab fix)

  ### New Features

  - `withHttpClient(Auth0HttpClient)` for custom HTTP client configuration (timeouts, proxies, etc.)
  - JPMS module support (`com.auth0.mvc.commons`)
  - ID Token validation delegated to `auth0-java` v3's `IdTokenVerifier`

  ### Deprecated API Removal

  - `handle(HttpServletRequest)` → use `handle(request, response)`
  - `buildAuthorizeUrl(request, uri)` → use 3-parameter version
  - `InvalidRequestException.getDescription()` → use `getMessage()`
  - `withHttpOptions(HttpOptions)` → use `withHttpClient(Auth0HttpClient)`
  - Removed custom verifier classes: `IdTokenVerifier`, `SignatureVerifier`, `AsymmetricSignatureVerifier`, `SymmetricSignatureVerifier`, `AlgorithmNameVerifier`, `TokenValidationException`
  - Removed session-based storage: `RandomStorage`, `SessionUtils`

  > **Note:** Session (HTTP Session) based state/nonce storage has been replaced with secure transient cookies — the library no longer uses `HttpSession` for OAuth state management.

  ---

  ## Breaking Changes
  
  | Change | Migration |
  |--------|-----------|
  | Java 17 required | Upgrade JDK/runtime |
  | `jakarta.servlet` namespace | Update imports; use Tomcat 10.1+, Jetty 12+, WildFly 27+ |
  | `handle(request)` removed | Use `handle(request, response)` |
  | `buildAuthorizeUrl(request, uri)` removed | Use `buildAuthorizeUrl(request, response, uri)` |
  | `InvalidRequestException.getDescription()` removed | Use `getMessage()` |
  | `withHttpOptions(HttpOptions)` removed | Use `withHttpClient(Auth0HttpClient)` |
  | Custom verifier classes removed | No action — handled internally |
  | Session-based storage removed | No action — cookies used automatically |

  ---

  ## Installation

  **Maven**

  ```xml
  <dependency>
    <groupId>com.auth0</groupId>
    <artifactId>mvc-auth-commons</artifactId>
    <version>2.0.0-beta.0</version>
  </dependency>

  Gradle

  implementation 'com.auth0:mvc-auth-commons:2.0.0-beta.0'

  ---
  Test Plan
  
  - All 189 tests passing across 8 test classes (Java 17)
  - Verified Code Grant flow (authorize → callback → token exchange)
  - Verified Implicit Grant flow (id_token token response type)
  - Verified multi-tab login isolation (concurrent state cookies coexist)
  - Verified MCD with HMAC-signed origin domain cookies
  - Verified MCD + PAR + JAR integration
  - Verified withHttpClient(Auth0HttpClient) — single client reused across MCD domains
  - Verified legacy cookie fallback for rolling upgrades
  - Confirmed v1 branch (master) unaffected