### PR TITLE
feat: Bumps auth0-java version to 4.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation 'com.google.guava:guava:32.0.1-jre'
     implementation 'commons-codec:commons-codec:1.22.0'
 
-    api 'com.auth0:auth0:3.10.0'
+    api 'com.auth0:auth0:4.1.0'
     api 'com.auth0:java-jwt:4.5.0'
     api 'com.auth0:jwks-rsa:0.24.1'
 


### PR DESCRIPTION
### Changes

- Bumps `auth0-java` version to `4.1.0`

### References

### Testing

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of Java or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
